### PR TITLE
test: raise coverage from 60% to 74%

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![CI](https://github.com/ulsreall/web3-agent-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/ulsreall/web3-agent-kit/actions)
 [![Docs](https://img.shields.io/badge/docs-site-blue.svg)](https://www.web3agentkit.site/)
 [![Website](https://img.shields.io/badge/website-live-10b981.svg)](https://www.web3agentkit.site/)
-[![Coverage](https://img.shields.io/badge/coverage-60%25-green.svg)](https://github.com/ulsreall/web3-agent-kit#readme)
+[![Coverage](https://img.shields.io/badge/coverage-73%25-green.svg)](https://github.com/ulsreall/web3-agent-kit#readme)
 [![Twitter](https://img.shields.io/twitter/follow/itseywacc?style=social)](https://twitter.com/itseywacc)
 
 <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ exclude_lines = [
     "except ImportError",
 ]
 show_missing = true
-fail_under = 60
+fail_under = 70
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/tests/test_agent_core_extra.py
+++ b/tests/test_agent_core_extra.py
@@ -1,0 +1,239 @@
+"""Extra tests for Agent core — run loop, observe, decide, LLM mocked."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from web3_agent_kit.agent.core import Agent, AgentConfig
+from web3_agent_kit.chains.chain import Chain
+from web3_agent_kit.wallet.wallet import Wallet
+
+TEST_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+
+def _wallet():
+    return Wallet.from_key(TEST_KEY)
+
+
+def _make_tool(name="swap", chains=None, result="ok"):
+    tool = MagicMock()
+    tool.name = name
+    tool.supported_chains = chains or [Chain.ETHEREUM]
+    tool.execute.return_value = result
+    return tool
+
+
+class TestAgentConstruction:
+    def test_init_with_private_key(self):
+        agent = Agent(private_key=TEST_KEY, governor=None)
+        assert agent.wallet.address.startswith("0x")
+
+    def test_init_with_wallet_kwarg(self):
+        agent = Agent(wallet=_wallet(), governor=None)
+        assert agent.wallet is not None
+
+    def test_init_missing_wallet_raises(self):
+        with pytest.raises(TypeError, match="requires wallet"):
+            Agent(governor=None)
+
+    def test_init_with_config(self):
+        cfg = AgentConfig(wallet=_wallet(), governor=None)
+        agent = Agent(config=cfg)
+        assert agent.config is cfg
+
+    def test_repr(self):
+        agent = Agent(wallet=_wallet(), governor=None, chains=[Chain.BASE])
+        r = repr(agent)
+        assert "Agent" in r
+        assert "BASE" in r
+
+    def test_confirm_fn_wired_into_default_governor(self):
+        confirm = MagicMock(return_value=True)
+        cfg = AgentConfig(wallet=_wallet(), confirm_fn=confirm)
+        agent = Agent(config=cfg)
+        assert agent.config.governor.confirm_fn is confirm
+
+
+class TestObserve:
+    def test_observe_success(self):
+        wallet = MagicMock()
+        wallet.address = "0xabc"
+        wallet.get_balance.return_value = 1.23
+        cfg = AgentConfig(wallet=wallet, chains=[Chain.ETHEREUM], governor=None)
+        agent = Agent(config=cfg)
+        obs = agent._observe()
+        assert "ETHEREUM" in obs
+        assert "1.23" in obs
+
+    def test_observe_error(self):
+        wallet = MagicMock()
+        wallet.address = "0xabc"
+        wallet.get_balance.side_effect = RuntimeError("rpc fail")
+        cfg = AgentConfig(wallet=wallet, chains=[Chain.ETHEREUM], governor=None)
+        agent = Agent(config=cfg)
+        obs = agent._observe()
+        assert "error" in obs
+
+
+class TestDecide:
+    def test_decide_returns_llm_response(self):
+        agent = Agent(wallet=_wallet(), governor=None, tools=[_make_tool()])
+        mock_llm = MagicMock()
+        mock_llm.chat_json.return_value = {"tool": "swap", "args": {"amount": 0.01}}
+        agent._llm = mock_llm
+        action = agent._decide("do a swap", "obs")
+        assert action["tool"] == "swap"
+
+    def test_decide_no_tools_uses_placeholder(self):
+        agent = Agent(wallet=_wallet(), governor=None)
+        mock_llm = MagicMock()
+        mock_llm.chat_json.return_value = {"tool": "done", "answer": "hi"}
+        agent._llm = mock_llm
+        action = agent._decide("goal", "obs")
+        assert action["tool"] == "done"
+
+    def test_decide_missing_tool_key_defaults_to_done(self):
+        agent = Agent(wallet=_wallet(), governor=None)
+        mock_llm = MagicMock()
+        mock_llm.chat_json.return_value = {"thought": "just thinking"}
+        agent._llm = mock_llm
+        action = agent._decide("goal", "obs")
+        assert action["tool"] == "done"
+        assert action["answer"] == "just thinking"
+
+    def test_decide_llm_exception_returns_done_error(self):
+        agent = Agent(wallet=_wallet(), governor=None)
+        mock_llm = MagicMock()
+        mock_llm.chat_json.side_effect = RuntimeError("llm broke")
+        agent._llm = mock_llm
+        action = agent._decide("goal", "obs")
+        assert action["tool"] == "done"
+        assert "LLM error" in action["answer"]
+
+    def test_decide_uses_history_context(self):
+        agent = Agent(wallet=_wallet(), governor=None, tools=[_make_tool()])
+        agent.history = [{"step": 1, "action": {"tool": "swap"}, "result": "done step"}]
+        mock_llm = MagicMock()
+        mock_llm.chat_json.return_value = {"tool": "done", "answer": "fin"}
+        agent._llm = mock_llm
+        action = agent._decide("goal", "obs")
+        # Ensure prompt building with history didn't crash
+        assert action["tool"] == "done"
+        assert mock_llm.chat_json.called
+
+
+class TestLLMProperty:
+    def test_llm_lazy_load(self):
+        agent = Agent(wallet=_wallet(), governor=None)
+        with patch("web3_agent_kit.agent.llm.LLM") as MockLLM:
+            MockLLM.return_value = "llm-instance"
+            llm = agent.llm
+            assert llm == "llm-instance"
+            # cached
+            assert agent.llm == "llm-instance"
+            MockLLM.assert_called_once()
+
+
+class TestRun:
+    def _agent_with_llm(self, responses, tools=None, governor=None, verbose=False):
+        wallet = MagicMock()
+        wallet.address = "0xabc"
+        wallet.get_balance.return_value = 1.0
+        cfg = AgentConfig(
+            wallet=wallet,
+            chains=[Chain.ETHEREUM],
+            tools=tools or [],
+            governor=governor,
+            verbose=verbose,
+        )
+        agent = Agent(config=cfg)
+        mock_llm = MagicMock()
+        mock_llm.chat_json.side_effect = responses
+        agent._llm = mock_llm
+        return agent
+
+    def test_run_completes_immediately(self):
+        agent = self._agent_with_llm([{"tool": "done", "answer": "all set"}])
+        result = agent.run("goal")
+        assert result == "all set"
+        assert len(agent.history) == 1
+
+    def test_run_executes_then_done(self):
+        tool = _make_tool(result="swapped 0.01")
+        agent = self._agent_with_llm(
+            [
+                {"tool": "swap", "args": {"amount": 0.01}},
+                {"tool": "done", "answer": "finished"},
+            ],
+            tools=[tool],
+        )
+        result = agent.run("swap something")
+        assert result == "finished"
+        assert len(agent.history) == 2
+        tool.execute.assert_called_once()
+
+    def test_run_max_steps_reached(self):
+        # Always returns a non-done action -> loop exhausts steps
+        tool = _make_tool()
+        agent = self._agent_with_llm(
+            [{"tool": "swap", "args": {"amount": 0.001}}] * 5,
+            tools=[tool],
+        )
+        result = agent.run("goal", max_steps=3)
+        assert "Max steps (3) reached" in result
+        assert len(agent.history) == 3
+
+    def test_run_verbose(self):
+        tool = _make_tool()
+        agent = self._agent_with_llm(
+            [
+                {"tool": "swap", "args": {"amount": 0.001}, "thought": "thinking"},
+                {"tool": "done", "answer": "done!", "thought": "wrapping up"},
+            ],
+            tools=[tool],
+            verbose=True,
+        )
+        result = agent.run("goal")
+        assert result == "done!"
+
+    def test_execute_alias(self):
+        agent = self._agent_with_llm([{"tool": "done", "answer": "via execute"}])
+        assert agent.execute("goal") == "via execute"
+
+
+class TestAct:
+    def test_act_unknown_tool(self):
+        agent = Agent(wallet=_wallet(), governor=None, tools=[_make_tool("swap")])
+        result = agent._act({"tool": "nonexistent", "args": {}})
+        assert "Unknown tool" in result
+
+    def test_act_tool_raises(self):
+        tool = _make_tool("swap")
+        tool.execute.side_effect = RuntimeError("execution failed")
+        agent = Agent(wallet=_wallet(), governor=None, tools=[tool])
+        result = agent._act({"tool": "swap", "args": {}})
+        assert "Error:" in result
+
+    def test_act_no_governor_executes(self):
+        tool = _make_tool("swap", result="did it")
+        agent = Agent(wallet=_wallet(), governor=None, tools=[tool])
+        result = agent._act({"tool": "swap", "args": {"amount": 100.0}})
+        assert result == "did it"
+
+
+class TestEstimateTxValue:
+    def test_value_key(self):
+        assert Agent._estimate_tx_value({"value": "0.5"}) == 0.5
+
+    def test_amount_in_key(self):
+        assert Agent._estimate_tx_value({"amount_in": 2}) == 2.0
+
+    def test_bad_value_returns_none(self):
+        assert Agent._estimate_tx_value({"amount": "not-a-number"}) is None
+
+    def test_no_key_returns_none(self):
+        assert Agent._estimate_tx_value({"foo": 1}) is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_airdrop_executor_cli.py
+++ b/tests/test_airdrop_executor_cli.py
@@ -1,0 +1,476 @@
+"""Tests for the airdrop executor CLI (web3_agent_kit.airdrop.executor.cli).
+
+All browser / playwright / network interactions are mocked so tests are
+fully offline. The AirdropTracker is patched with a MagicMock to avoid
+touching the filesystem (~/.web3-agent-kit/airdrops.json).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from web3_agent_kit.airdrop.executor import cli as cli_mod
+from web3_agent_kit.airdrop.executor.cli import (
+    _display_gleam_result,
+    _display_zealy_result,
+    _make_progress_bar,
+    main,
+)
+
+runner = CliRunner()
+
+
+# === main group ===
+
+
+class TestMainGroup:
+    def test_help(self):
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "Airdrop farming" in result.output
+
+    def test_version(self):
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "0.8.0" in result.output
+
+    def test_farm_group_help(self):
+        result = runner.invoke(main, ["farm", "--help"])
+        assert result.exit_code == 0
+        for sub in ("gleam", "zealy", "status", "export"):
+            assert sub in result.output
+
+    def test_browser_group_help(self):
+        result = runner.invoke(main, ["browser", "--help"])
+        assert result.exit_code == 0
+        assert "login" in result.output
+        assert "sessions" in result.output
+
+
+# === helper: _ensure_playwright ===
+
+
+class TestEnsurePlaywright:
+    def test_playwright_available(self):
+        mock_browser = SimpleNamespace(HAS_PLAYWRIGHT=True)
+        with patch.dict(
+            "sys.modules",
+            {"web3_agent_kit.airdrop.executor.browser": mock_browser},
+        ):
+            # should not raise / not exit
+            cli_mod._ensure_playwright()
+
+    def test_playwright_missing_exits(self):
+        mock_browser = SimpleNamespace(HAS_PLAYWRIGHT=False)
+        with patch.dict(
+            "sys.modules",
+            {"web3_agent_kit.airdrop.executor.browser": mock_browser},
+        ):
+            try:
+                cli_mod._ensure_playwright()
+                raised = False
+            except SystemExit as e:
+                raised = True
+                assert e.code == 1
+            assert raised
+
+
+# === farm gleam ===
+
+
+def _make_gleam_result():
+    return SimpleNamespace(
+        is_fully_completed=True,
+        total_tasks=5,
+        completed_tasks=5,
+        failed_tasks=0,
+        skipped_tasks=0,
+        success_rate=1.0,
+        elapsed_seconds=12.3,
+        errors=[],
+    )
+
+
+class TestFarmGleam:
+    def test_farm_gleam_success(self):
+        mock_executor = MagicMock()
+        mock_executor.complete_all.return_value = _make_gleam_result()
+        mock_browser_ctx = MagicMock()
+        mock_browser_ctx.__enter__.return_value = MagicMock()
+        mock_browser_ctx.__exit__.return_value = False
+
+        fake_browser_mod = SimpleNamespace(
+            BrowserConfig=MagicMock(),
+            BrowserManager=MagicMock(return_value=mock_browser_ctx),
+        )
+        fake_gleam_mod = SimpleNamespace(
+            GleamExecutor=MagicMock(return_value=mock_executor)
+        )
+
+        with patch.object(cli_mod, "_ensure_playwright"), patch.object(
+            cli_mod, "AirdropTracker", MagicMock()
+        ), patch.dict(
+            "sys.modules",
+            {
+                "web3_agent_kit.airdrop.executor.browser": fake_browser_mod,
+                "web3_agent_kit.airdrop.executor.gleam_exec": fake_gleam_mod,
+            },
+        ):
+            result = runner.invoke(main, ["farm", "gleam", "https://gleam.io/abc"])
+
+        assert result.exit_code == 0
+        assert "Gleam.io Farming" in result.output
+        assert "All tasks completed" in result.output
+
+    def test_farm_gleam_error_exits(self):
+        mock_browser_ctx = MagicMock()
+        mock_browser_ctx.__enter__.side_effect = RuntimeError("boom")
+
+        fake_browser_mod = SimpleNamespace(
+            BrowserConfig=MagicMock(),
+            BrowserManager=MagicMock(return_value=mock_browser_ctx),
+        )
+        fake_gleam_mod = SimpleNamespace(GleamExecutor=MagicMock())
+
+        with patch.object(cli_mod, "_ensure_playwright"), patch.object(
+            cli_mod, "AirdropTracker", MagicMock()
+        ), patch.dict(
+            "sys.modules",
+            {
+                "web3_agent_kit.airdrop.executor.browser": fake_browser_mod,
+                "web3_agent_kit.airdrop.executor.gleam_exec": fake_gleam_mod,
+            },
+        ):
+            result = runner.invoke(
+                main, ["farm", "gleam", "https://gleam.io/abc", "--proxy", "http://p"]
+            )
+
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+# === farm zealy ===
+
+
+def _make_zealy_result():
+    return SimpleNamespace(
+        completed_quests=3,
+        total_quests=3,
+        xp_earned=300,
+        failed_quests=0,
+        success_rate=1.0,
+        elapsed_seconds=8.0,
+        errors=[],
+    )
+
+
+class TestFarmZealy:
+    def test_farm_zealy_success(self):
+        mock_executor = MagicMock()
+        mock_executor.complete_all.return_value = _make_zealy_result()
+        mock_browser_ctx = MagicMock()
+        mock_browser_ctx.__enter__.return_value = MagicMock()
+        mock_browser_ctx.__exit__.return_value = False
+
+        fake_browser_mod = SimpleNamespace(
+            BrowserConfig=MagicMock(),
+            BrowserManager=MagicMock(return_value=mock_browser_ctx),
+        )
+        fake_zealy_mod = SimpleNamespace(
+            ZealyExecutor=MagicMock(return_value=mock_executor)
+        )
+
+        with patch.object(cli_mod, "_ensure_playwright"), patch.object(
+            cli_mod, "AirdropTracker", MagicMock()
+        ), patch.dict(
+            "sys.modules",
+            {
+                "web3_agent_kit.airdrop.executor.browser": fake_browser_mod,
+                "web3_agent_kit.airdrop.executor.zealy_exec": fake_zealy_mod,
+            },
+        ):
+            result = runner.invoke(main, ["farm", "zealy", "https://zealy.io/c/x"])
+
+        assert result.exit_code == 0
+        assert "Zealy Quest Farming" in result.output
+        assert "All quests completed" in result.output
+
+    def test_farm_zealy_error_exits(self):
+        mock_browser_ctx = MagicMock()
+        mock_browser_ctx.__enter__.side_effect = RuntimeError("boom")
+
+        fake_browser_mod = SimpleNamespace(
+            BrowserConfig=MagicMock(),
+            BrowserManager=MagicMock(return_value=mock_browser_ctx),
+        )
+        fake_zealy_mod = SimpleNamespace(ZealyExecutor=MagicMock())
+
+        with patch.object(cli_mod, "_ensure_playwright"), patch.object(
+            cli_mod, "AirdropTracker", MagicMock()
+        ), patch.dict(
+            "sys.modules",
+            {
+                "web3_agent_kit.airdrop.executor.browser": fake_browser_mod,
+                "web3_agent_kit.airdrop.executor.zealy_exec": fake_zealy_mod,
+            },
+        ):
+            result = runner.invoke(main, ["farm", "zealy", "https://zealy.io/c/x"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+# === farm status ===
+
+
+def _make_campaign(**kw):
+    defaults = dict(
+        name="Test Campaign",
+        platform="gleam",
+        progress=0.5,
+        earned_points=50.0,
+        total_points=100.0,
+        url="https://gleam.io/abc",
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def _make_summary(campaigns=0, active=0, rewards=None):
+    return SimpleNamespace(
+        total_campaigns=campaigns,
+        active_campaigns=active,
+        completed_tasks=0,
+        total_points=0.0,
+        total_rewards=rewards or [],
+    )
+
+
+class TestFarmStatus:
+    def test_status_empty(self):
+        tracker = MagicMock()
+        tracker.list_campaigns.return_value = []
+        tracker.get_summary.return_value = _make_summary()
+        with patch.object(cli_mod, "AirdropTracker", return_value=tracker):
+            result = runner.invoke(main, ["farm", "status"])
+        assert result.exit_code == 0
+        assert "No tracked campaigns" in result.output
+
+    def test_status_with_campaigns_and_rewards(self):
+        tracker = MagicMock()
+        tracker.list_campaigns.return_value = [_make_campaign()]
+        reward = SimpleNamespace(
+            claimed=True,
+            campaign_name="Test Campaign",
+            points=50,
+            tokens=1.5,
+            token_symbol="ABC",
+        )
+        tracker.get_summary.return_value = _make_summary(
+            campaigns=1, active=1, rewards=[reward]
+        )
+        with patch.object(cli_mod, "AirdropTracker", return_value=tracker):
+            result = runner.invoke(main, ["farm", "status", "--all"])
+        assert result.exit_code == 0
+        assert "Test Campaign" in result.output
+        assert "Rewards" in result.output
+
+    def test_status_platform_filter(self):
+        tracker = MagicMock()
+        tracker.list_campaigns.return_value = [_make_campaign(url="")]
+        tracker.get_summary.return_value = _make_summary(campaigns=1, active=1)
+        with patch.object(cli_mod, "AirdropTracker", return_value=tracker):
+            result = runner.invoke(
+                main, ["farm", "status", "--platform", "gleam"]
+            )
+        assert result.exit_code == 0
+        tracker.list_campaigns.assert_called_once()
+
+
+# === farm export ===
+
+
+class TestFarmExport:
+    def test_export_json(self):
+        tracker = MagicMock()
+        with patch.object(cli_mod, "AirdropTracker", return_value=tracker):
+            result = runner.invoke(
+                main, ["farm", "export", "--format", "json", "-o", "out.json"]
+            )
+        assert result.exit_code == 0
+        assert "Exported to out.json" in result.output
+        tracker.export_json.assert_called_once_with("out.json")
+
+    def test_export_csv_default_name(self):
+        tracker = MagicMock()
+        with patch.object(cli_mod, "AirdropTracker", return_value=tracker):
+            result = runner.invoke(main, ["farm", "export"])
+        assert result.exit_code == 0
+        assert "Exported to" in result.output
+        tracker.export_csv.assert_called_once()
+
+
+# === browser login ===
+
+
+class TestBrowserLogin:
+    def _run_login(self, platform, exec_attr, success):
+        mock_browser = MagicMock()
+        mock_executor = MagicMock()
+        mock_executor.interactive_login.return_value = success
+        fake_social = SimpleNamespace(**{exec_attr: MagicMock(return_value=mock_executor)})
+        with patch.object(cli_mod, "_ensure_playwright"), patch.object(
+            cli_mod, "_get_browser", return_value=mock_browser
+        ), patch.dict(
+            "sys.modules",
+            {"web3_agent_kit.airdrop.executor.social_exec": fake_social},
+        ):
+            result = runner.invoke(main, ["browser", "login", platform])
+        mock_browser.close.assert_called_once()
+        return result
+
+    def test_twitter_login_success(self):
+        result = self._run_login("twitter", "TwitterExecutor", True)
+        assert result.exit_code == 0
+        assert "Twitter login saved" in result.output
+
+    def test_twitter_login_failed(self):
+        result = self._run_login("twitter", "TwitterExecutor", False)
+        assert result.exit_code == 0
+        assert "Twitter login failed" in result.output
+
+    def test_discord_login_success(self):
+        result = self._run_login("discord", "DiscordExecutor", True)
+        assert result.exit_code == 0
+        assert "Discord login saved" in result.output
+
+    def test_telegram_login_success(self):
+        result = self._run_login("telegram", "TelegramExecutor", True)
+        assert result.exit_code == 0
+        assert "Telegram login saved" in result.output
+
+    def test_invalid_platform_rejected(self):
+        with patch.object(cli_mod, "_ensure_playwright"):
+            result = runner.invoke(main, ["browser", "login", "myspace"])
+        assert result.exit_code != 0
+
+
+# === browser sessions ===
+
+
+class TestBrowserSessions:
+    def test_sessions_none(self, tmp_path):
+        missing = tmp_path / "nope"
+        fake_browser = SimpleNamespace(SESSIONS_DIR=missing)
+        with patch.dict(
+            "sys.modules",
+            {"web3_agent_kit.airdrop.executor.browser": fake_browser},
+        ):
+            result = runner.invoke(main, ["browser", "sessions"])
+        assert result.exit_code == 0
+        assert "No saved sessions" in result.output
+
+    def test_sessions_listed(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        sess = sessions / "twitter"
+        sess.mkdir()
+        (sess / "cookies.json").write_text('{"a": 1}')
+        # a platform subdir with cookies
+        sub = sess / "sub"
+        sub.mkdir()
+        (sub / "cookies.json").write_text("{}")
+        # a session without cookies
+        empty = sessions / "empty"
+        empty.mkdir()
+
+        fake_browser = SimpleNamespace(SESSIONS_DIR=sessions)
+        with patch.dict(
+            "sys.modules",
+            {"web3_agent_kit.airdrop.executor.browser": fake_browser},
+        ):
+            result = runner.invoke(main, ["browser", "sessions"])
+        assert result.exit_code == 0
+        assert "Saved Sessions" in result.output
+        assert "twitter" in result.output
+        assert "empty" in result.output
+
+
+# === _get_browser ===
+
+
+class TestGetBrowser:
+    def test_get_browser_default_config(self):
+        fake_browser = SimpleNamespace(
+            BrowserConfig=MagicMock(return_value="cfg"),
+            BrowserManager=MagicMock(return_value="mgr"),
+        )
+        with patch.dict(
+            "sys.modules",
+            {"web3_agent_kit.airdrop.executor.browser": fake_browser},
+        ):
+            result = cli_mod._get_browser()
+        assert result == "mgr"
+        fake_browser.BrowserManager.assert_called_once_with("cfg")
+
+    def test_get_browser_explicit_config(self):
+        fake_browser = SimpleNamespace(
+            BrowserConfig=MagicMock(),
+            BrowserManager=MagicMock(return_value="mgr"),
+        )
+        with patch.dict(
+            "sys.modules",
+            {"web3_agent_kit.airdrop.executor.browser": fake_browser},
+        ):
+            result = cli_mod._get_browser(config="mycfg")
+        assert result == "mgr"
+        fake_browser.BrowserManager.assert_called_once_with("mycfg")
+        fake_browser.BrowserConfig.assert_not_called()
+
+
+# === display helpers ===
+
+
+class TestDisplayHelpers:
+    def test_display_gleam_fully_completed(self):
+        # Just ensure no exception; helpers use click.echo which needs no context here.
+        _display_gleam_result(_make_gleam_result())
+
+    def test_display_gleam_with_issues(self):
+        result = SimpleNamespace(
+            is_fully_completed=False,
+            total_tasks=5,
+            completed_tasks=3,
+            failed_tasks=1,
+            skipped_tasks=1,
+            success_rate=0.6,
+            elapsed_seconds=5.0,
+            errors=["err1", "err2"],
+        )
+        _display_gleam_result(result)
+
+    def test_display_zealy_fully_completed(self):
+        _display_zealy_result(_make_zealy_result())
+
+    def test_display_zealy_with_issues(self):
+        result = SimpleNamespace(
+            completed_quests=1,
+            total_quests=3,
+            xp_earned=100,
+            failed_quests=2,
+            success_rate=0.33,
+            elapsed_seconds=4.0,
+            errors=["boom"],
+        )
+        _display_zealy_result(result)
+
+    def test_make_progress_bar(self):
+        assert _make_progress_bar(0.0).count("█") == 0
+        assert _make_progress_bar(1.0).count("█") == 20
+        # clamps above 1.0
+        assert _make_progress_bar(2.0).count("█") == 20
+        half = _make_progress_bar(0.5, width=10)
+        assert half.count("█") == 5

--- a/tests/test_airdrop_sched_dash.py
+++ b/tests/test_airdrop_sched_dash.py
@@ -1,0 +1,474 @@
+"""Extra tests for AirdropScheduler and PointsDashboard."""
+
+import asyncio
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from web3_agent_kit.airdrop.dashboard import (
+    DashboardConfig,
+    PlatformPoints,
+    PointsDashboard,
+    PointsSnapshot,
+)
+from web3_agent_kit.airdrop.scheduler import (
+    AirdropScheduler,
+    ExecutionLog,
+    ScheduledTask,
+    ScheduleFrequency,
+    SchedulerConfig,
+    TaskExecutionStatus,
+)
+
+
+@pytest.fixture
+def tmp_json():
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        path = f.name
+    os.unlink(path)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+# ─── Scheduler ───────────────────────────────────────────────────
+
+
+class TestScheduledTask:
+    def test_success_rate_zero(self):
+        t = ScheduledTask("id", "n", ScheduleFrequency.DAILY)
+        assert t.success_rate == 0.0
+
+    def test_success_rate(self):
+        t = ScheduledTask("id", "n", ScheduleFrequency.DAILY)
+        t.total_runs = 4
+        t.total_successes = 3
+        assert t.success_rate == 0.75
+
+    def test_is_due_disabled(self):
+        t = ScheduledTask("id", "n", ScheduleFrequency.DAILY, enabled=False)
+        assert t.is_due is False
+
+    def test_is_due_no_next_run(self):
+        t = ScheduledTask("id", "n", ScheduleFrequency.DAILY)
+        assert t.is_due is True
+
+    def test_is_due_past(self):
+        t = ScheduledTask("id", "n", ScheduleFrequency.DAILY)
+        t.next_run = datetime.now(timezone.utc) - timedelta(hours=1)
+        assert t.is_due is True
+
+    def test_is_due_future(self):
+        t = ScheduledTask("id", "n", ScheduleFrequency.DAILY)
+        t.next_run = datetime.now(timezone.utc) + timedelta(hours=1)
+        assert t.is_due is False
+
+    def test_to_dict(self):
+        t = ScheduledTask("id", "n", ScheduleFrequency.DAILY, platform="galxe")
+        d = t.to_dict()
+        assert d["task_id"] == "id"
+        assert d["frequency"] == "daily"
+        assert d["platform"] == "galxe"
+        assert d["success_rate"] == 0.0
+
+
+class TestSchedulerAdd:
+    def test_add_daily(self):
+        s = AirdropScheduler()
+        t = s.add_daily("t1", "09:00", lambda: None, platform="galxe")
+        assert t.frequency == ScheduleFrequency.DAILY
+        assert t.target_time == "09:00"
+        assert t.next_run is not None
+        assert s.get_task("t1") is t
+
+    def test_add_hourly(self):
+        s = AirdropScheduler()
+        t = s.add_hourly("t2", lambda: None)
+        assert t.frequency == ScheduleFrequency.HOURLY
+        assert t.next_run is not None
+
+    def test_add_weekly(self):
+        s = AirdropScheduler()
+        t = s.add_weekly("t3", 2, "10:00", lambda: None)
+        assert t.frequency == ScheduleFrequency.WEEKLY
+        assert t.next_run is not None
+
+    def test_add_custom(self):
+        s = AirdropScheduler()
+        t = s.add_custom("t4", 30.0, lambda: None)
+        assert t.frequency == ScheduleFrequency.CUSTOM
+        assert t.metadata["interval_seconds"] == 30.0
+
+
+class TestSchedulerManage:
+    def test_remove(self):
+        s = AirdropScheduler()
+        s.add_daily("t1", "09:00", lambda: None)
+        assert s.remove_task("t1") is True
+        assert s.remove_task("t1") is False
+
+    def test_enable_disable(self):
+        s = AirdropScheduler()
+        s.add_daily("t1", "09:00", lambda: None)
+        assert s.disable_task("t1") is True
+        assert s.get_task("t1").enabled is False
+        assert s.enable_task("t1") is True
+        assert s.get_task("t1").enabled is True
+        assert s.enable_task("missing") is False
+        assert s.disable_task("missing") is False
+
+    def test_get_all_and_due(self):
+        s = AirdropScheduler()
+        s.add_daily("t1", "09:00", lambda: None)
+        t2 = s.add_daily("t2", "10:00", lambda: None)
+        t2.next_run = datetime.now(timezone.utc) + timedelta(days=1)
+        assert len(s.get_all_tasks()) == 2
+        due_ids = [t.task_id for t in s.get_due_tasks()]
+        assert "t1" not in due_ids or "t2" not in due_ids
+
+    def test_get_summary(self):
+        s = AirdropScheduler()
+        s.add_daily("t1", "09:00", lambda: None)
+        s.add_daily("t2", "10:00", lambda: None, enabled=False)
+        summary = s.get_summary()
+        assert summary["total_tasks"] == 2
+        assert summary["enabled_tasks"] == 1
+        assert summary["disabled_tasks"] == 1
+
+
+class TestSchedulerExecution:
+    def test_run_task_now_success(self):
+        s = AirdropScheduler()
+        cb = MagicMock(return_value="ok")
+        s.add_daily("t1", "09:00", cb)
+        log = asyncio.run(s.run_task_now("t1"))
+        assert log.status == TaskExecutionStatus.SUCCESS
+        assert log.result == "ok"
+        assert s.get_task("t1").total_successes == 1
+        cb.assert_called_once()
+
+    def test_run_task_now_missing(self):
+        s = AirdropScheduler()
+        assert asyncio.run(s.run_task_now("nope")) is None
+
+    def test_run_task_no_callback(self):
+        s = AirdropScheduler()
+        s._tasks["t1"] = ScheduledTask("t1", "n", ScheduleFrequency.DAILY)
+        log = asyncio.run(s.run_task_now("t1"))
+        assert log.status == TaskExecutionStatus.SKIPPED
+
+    def test_run_task_failure(self):
+        s = AirdropScheduler()
+        cb = MagicMock(side_effect=RuntimeError("boom"))
+        # retry_delay 0 to keep test fast; max_retries 2
+        s.add_daily("t1", "09:00", cb, max_retries=2)
+        s.get_task("t1").retry_delay = 0
+        log = asyncio.run(s.run_task_now("t1"))
+        assert log.status == TaskExecutionStatus.FAILED
+        assert "boom" in log.error
+        assert s.get_task("t1").consecutive_failures == 2
+
+    def test_execution_log_filter(self):
+        s = AirdropScheduler()
+        s.add_daily("t1", "09:00", MagicMock(return_value=1))
+        s.add_daily("t2", "09:00", MagicMock(return_value=2))
+        asyncio.run(s.run_task_now("t1"))
+        asyncio.run(s.run_task_now("t2"))
+        assert len(s.get_execution_log()) == 2
+        assert len(s.get_execution_log(task_id="t1")) == 1
+
+
+class TestSchedulerCalc:
+    def test_next_run_daily(self):
+        s = AirdropScheduler()
+        nr = s._calculate_next_run(ScheduleFrequency.DAILY, "09:00")
+        assert nr.hour == 9 and nr.minute == 0
+
+    def test_next_run_hourly(self):
+        s = AirdropScheduler()
+        nr = s._calculate_next_run(ScheduleFrequency.HOURLY)
+        assert nr > datetime.now(timezone.utc)
+
+    def test_next_run_custom(self):
+        s = AirdropScheduler()
+        nr = s._calculate_next_run(ScheduleFrequency.CUSTOM)
+        assert nr > datetime.now(timezone.utc)
+
+    def test_next_weekly(self):
+        s = AirdropScheduler()
+        nr = s._calculate_next_weekly(0, "08:30")
+        assert nr.hour == 8 and nr.minute == 30
+        assert nr > datetime.now(timezone.utc)
+
+
+class TestSchedulerPersistence:
+    def test_export_state(self, tmp_json):
+        s = AirdropScheduler()
+        s.add_daily("t1", "09:00", lambda: None)
+        s.export_state(tmp_json)
+        data = json.loads(open(tmp_json).read())
+        assert "t1" in data["tasks"]
+
+    def test_save_state_configured(self, tmp_json):
+        s = AirdropScheduler(SchedulerConfig(state_path=tmp_json))
+        s.add_daily("t1", "09:00", lambda: None)
+        s._save_state()
+        assert os.path.exists(tmp_json)
+        data = json.loads(open(tmp_json).read())
+        assert "t1" in data["tasks"]
+
+    def test_load_state(self, tmp_json):
+        with open(tmp_json, "w") as f:
+            json.dump({"tasks": {"a": {}, "b": {}}}, f)
+        # Should load without raising
+        s = AirdropScheduler(SchedulerConfig(state_path=tmp_json))
+        assert s is not None
+
+    def test_load_state_corrupt(self, tmp_json):
+        with open(tmp_json, "w") as f:
+            f.write("bad json {{{")
+        s = AirdropScheduler(SchedulerConfig(state_path=tmp_json))
+        assert s is not None
+
+    def test_log_execution_to_file(self, tmp_json):
+        s = AirdropScheduler(SchedulerConfig(log_path=tmp_json))
+        log = ExecutionLog(
+            task_id="t1", started_at=datetime.now(timezone.utc)
+        )
+        log.finished_at = datetime.now(timezone.utc)
+        s._log_execution(log)
+        assert os.path.exists(tmp_json)
+        assert "t1" in open(tmp_json).read()
+
+    def test_execution_log_to_dict(self):
+        log = ExecutionLog(
+            task_id="t1", started_at=datetime.now(timezone.utc)
+        )
+        d = log.to_dict()
+        assert d["task_id"] == "t1"
+        assert d["finished_at"] is None
+
+
+# ─── Dashboard ───────────────────────────────────────────────────
+
+
+class TestPlatformPoints:
+    def test_total_with_referrals(self):
+        p = PlatformPoints("galxe", points=100, referral_points=25)
+        assert p.total_with_referrals == 125
+
+    def test_to_dict(self):
+        p = PlatformPoints("galxe", points=100, rank=5, tier="gold")
+        d = p.to_dict()
+        assert d["platform"] == "galxe"
+        assert d["points"] == 100
+        assert d["last_activity"] is None
+
+
+class TestPointsSnapshot:
+    def test_totals(self):
+        snap = PointsSnapshot(
+            timestamp=datetime.now(timezone.utc),
+            platforms={
+                "galxe": PlatformPoints("galxe", points=100,
+                                        campaigns_completed=3),
+                "layer3": PlatformPoints("layer3", points=50,
+                                         campaigns_completed=1),
+            },
+        )
+        assert snap.total_points == 150
+        assert snap.total_campaigns == 4
+        assert snap.to_dict()["total_points"] == 150
+
+
+class TestDashboardSync:
+    def test_sync_requires_wallet(self):
+        d = PointsDashboard()
+        with pytest.raises(ValueError, match="Wallet address required"):
+            d.sync_all()
+
+    def test_sync_all_with_mocked_syncers(self):
+        cfg = DashboardConfig(platforms=["galxe", "zealy"])
+        d = PointsDashboard(cfg)
+        d._sync_galxe = MagicMock(
+            return_value=PlatformPoints("galxe", points=500)
+        )
+        d._sync_zealy = MagicMock(
+            return_value=PlatformPoints("zealy", points=0)
+        )
+        snap = d.sync_all(wallet="0xABC")
+        assert snap.total_points == 500
+        assert d.get_current() is snap
+
+    def test_sync_skips_unknown_platform(self):
+        cfg = DashboardConfig(platforms=["unknown_platform"])
+        d = PointsDashboard(cfg)
+        snap = d.sync_all(wallet="0xABC")
+        assert snap.total_points == 0
+
+    def test_sync_handles_syncer_error(self):
+        cfg = DashboardConfig(platforms=["galxe"])
+        d = PointsDashboard(cfg)
+        d._sync_galxe = MagicMock(side_effect=RuntimeError("api down"))
+        snap = d.sync_all(wallet="0xABC")
+        assert snap.total_points == 0
+
+
+class TestDashboardSyncers:
+    def test_sync_galxe(self):
+        d = PointsDashboard()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "data": {
+                "user": {
+                    "galxeScore": {"score": 1200, "rank": 42},
+                    "participatedCampaignCount": 7,
+                }
+            }
+        }
+        d.session.post = MagicMock(return_value=resp)
+        pts = d._sync_galxe("0xABC")
+        assert pts.points == 1200
+        assert pts.rank == 42
+        assert pts.campaigns_completed == 7
+
+    def test_sync_galxe_error(self):
+        d = PointsDashboard()
+        d.session.post = MagicMock(side_effect=RuntimeError("net"))
+        assert d._sync_galxe("0xABC") is None
+
+    def test_sync_layer3(self):
+        d = PointsDashboard()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"xp": 300, "questsCompleted": 5}
+        d.session.get = MagicMock(return_value=resp)
+        pts = d._sync_layer3("0xABC")
+        assert pts.points == 300
+        assert pts.campaigns_completed == 5
+
+    def test_sync_layer3_non_200(self):
+        d = PointsDashboard()
+        resp = MagicMock()
+        resp.status_code = 404
+        d.session.get = MagicMock(return_value=resp)
+        assert d._sync_layer3("0xABC") is None
+
+    def test_stub_syncers(self):
+        d = PointsDashboard()
+        assert d._sync_zealy("0xA").platform == "zealy"
+        assert d._sync_questn("0xA").platform == "questn"
+        assert d._sync_taskon("0xA").platform == "taskon"
+        assert d._sync_intract("0xA").platform == "intract"
+        assert d._sync_port3("0xA").platform == "port3"
+
+
+class TestDashboardReporting:
+    def _synced(self):
+        d = PointsDashboard(DashboardConfig(wallet_address="0xABCDEF0123456789"))
+        d._current = PointsSnapshot(
+            timestamp=datetime.now(timezone.utc),
+            platforms={
+                "galxe": PlatformPoints("galxe", points=1500, rank=10,
+                                        campaigns_completed=5, streak_days=3),
+                "layer3": PlatformPoints("layer3", points=800,
+                                         campaigns_completed=2),
+            },
+        )
+        return d
+
+    def test_get_history(self):
+        d = self._synced()
+        d._history = [d._current, d._current]
+        assert len(d.get_history()) == 2
+        assert len(d.get_history(limit=1)) == 1
+
+    def test_get_growth_insufficient(self):
+        d = PointsDashboard()
+        assert d.get_growth()["total_delta"] == 0
+
+    def test_get_growth(self):
+        d = PointsDashboard()
+        old = PointsSnapshot(
+            timestamp=datetime.now(timezone.utc) - timedelta(days=10),
+            platforms={"galxe": PlatformPoints("galxe", points=100)},
+        )
+        new = PointsSnapshot(
+            timestamp=datetime.now(timezone.utc),
+            platforms={"galxe": PlatformPoints("galxe", points=250)},
+        )
+        d._history = [old, new]
+        growth = d.get_growth(days=30)
+        assert growth["total_delta"] == 150
+        assert growth["platforms"]["galxe"]["delta"] == 150
+
+    def test_leaderboard_position(self):
+        d = self._synced()
+        positions = d.get_leaderboard_position()
+        assert positions[0]["platform"] == "galxe"
+        assert positions[0]["points"] == 1500
+
+    def test_leaderboard_no_data(self):
+        d = PointsDashboard()
+        assert d.get_leaderboard_position() == []
+
+    def test_print_summary_not_synced(self):
+        d = PointsDashboard()
+        assert "Not synced" in d.print_summary()
+
+    def test_print_summary(self, capsys):
+        d = self._synced()
+        out = d.print_summary()
+        assert "DASHBOARD" in out
+
+    def test_export_json(self, tmp_json):
+        d = self._synced()
+        js = d.export_json(tmp_json)
+        assert os.path.exists(tmp_json)
+        data = json.loads(js)
+        assert data["current"]["total_points"] == 2300
+
+    def test_export_markdown(self, tmp_json):
+        d = self._synced()
+        md = d.export_markdown(tmp_json)
+        assert "Airdrop Points Report" in md
+        assert os.path.exists(tmp_json)
+
+    def test_export_markdown_no_data(self):
+        d = PointsDashboard()
+        assert "No data" in d.export_markdown()
+
+
+class TestDashboardPersistence:
+    def test_save_and_load_history(self, tmp_json):
+        cfg = DashboardConfig(
+            wallet_address="0xABC", history_path=tmp_json,
+            platforms=["galxe"],
+        )
+        d = PointsDashboard(cfg)
+        d._sync_galxe = MagicMock(
+            return_value=PlatformPoints("galxe", points=999,
+                                        campaigns_completed=1)
+        )
+        d.sync_all(wallet="0xABC")
+        assert os.path.exists(tmp_json)
+        # New dashboard loads history
+        d2 = PointsDashboard(cfg)
+        assert len(d2._history) == 1
+        assert d2._history[0].total_points == 999
+
+    def test_load_history_corrupt(self, tmp_json):
+        with open(tmp_json, "w") as f:
+            f.write("not json {{{")
+        cfg = DashboardConfig(history_path=tmp_json)
+        d = PointsDashboard(cfg)
+        assert d._history == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1,0 +1,184 @@
+"""Tests for the API pydantic request/response models."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import web3_agent_kit.api.models as m
+
+    MODELS_AVAILABLE = True
+except ImportError:
+    MODELS_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not MODELS_AVAILABLE, reason="pydantic/models not installed"
+)
+
+
+class TestWalletModels:
+    def test_create_wallet_defaults(self):
+        req = m.CreateWalletRequest()
+        assert req.chain == "ethereum"
+
+    def test_import_wallet_requires_private_key(self):
+        with pytest.raises(Exception):
+            m.ImportWalletRequest()
+        req = m.ImportWalletRequest(private_key="0xabc")
+        assert req.private_key == "0xabc"
+        assert req.chain == "ethereum"
+
+    def test_wallet_response_optional_balance(self):
+        resp = m.WalletResponse(address="0x1", chain="ethereum")
+        assert resp.balance is None
+        resp2 = m.WalletResponse(address="0x1", chain="ethereum", balance="1.0")
+        assert resp2.balance == "1.0"
+
+
+class TestSwapModels:
+    def test_swap_request_defaults(self):
+        req = m.SwapRequest(token_in="ETH", token_out="USDC", amount_in="1.0")
+        assert req.chain == "ethereum"
+        assert req.slippage == 0.5
+        assert req.private_key is None
+
+    def test_swap_request_missing_required(self):
+        with pytest.raises(Exception):
+            m.SwapRequest(token_in="ETH")
+
+    def test_swap_quote_response(self):
+        resp = m.SwapQuoteResponse(
+            token_in="ETH",
+            token_out="USDC",
+            amount_in="1.0",
+            estimated_out="3500",
+            price_impact=0.01,
+            route=["ETH", "USDC"],
+        )
+        assert resp.route == ["ETH", "USDC"]
+
+
+class TestPortfolioModels:
+    def test_portfolio_request_defaults(self):
+        req = m.PortfolioRequest()
+        assert req.chain == "ethereum"
+        assert req.address is None
+
+    def test_portfolio_response(self):
+        resp = m.PortfolioResponse(
+            address="0x1",
+            chain="ethereum",
+            native_balance="1.0",
+            native_symbol="ETH",
+            tokens=[{"symbol": "USDC"}],
+            total_value_usd=100.0,
+        )
+        assert resp.tokens[0]["symbol"] == "USDC"
+
+
+class TestGasModels:
+    def test_gas_request_default(self):
+        assert m.GasRequest().chain == "ethereum"
+
+    def test_gas_response(self):
+        resp = m.GasResponse(
+            chain="ethereum",
+            base_fee=1,
+            low={"max_fee": 1},
+            medium={"max_fee": 2},
+            high={"max_fee": 3},
+            recommendation="now",
+        )
+        assert resp.recommendation == "now"
+
+
+class TestWatcherModels:
+    def test_watch_request(self):
+        req = m.WatchRequest(address="0x1")
+        assert req.tags == []
+        assert req.label == ""
+
+    def test_watch_request_missing_address(self):
+        with pytest.raises(Exception):
+            m.WatchRequest()
+
+    def test_alert_request(self):
+        req = m.AlertRequest(message="hi")
+        assert req.severity == "medium"
+
+
+class TestApprovalModels:
+    def test_scan_request_defaults(self):
+        req = m.ApprovalScanRequest()
+        assert req.chain == "ethereum"
+        assert req.address is None
+
+    def test_revoke_request(self):
+        req = m.RevokeRequest(token="0xtok", spender="0xsp")
+        assert req.token == "0xtok"
+        with pytest.raises(Exception):
+            m.RevokeRequest(token="0xtok")
+
+
+class TestDCAModels:
+    def test_dca_order_request(self):
+        req = m.DCAOrderRequest(
+            token_in="USDC", token_out="ETH", amount_per_buy="100"
+        )
+        assert req.frequency == "daily"
+        assert req.total_buys is None
+
+    def test_dca_status_response(self):
+        resp = m.DCAStatusResponse(
+            order_id="d1",
+            status="active",
+            buys_executed=1,
+            total_buys=5,
+            avg_price=3500.0,
+            total_spent="100",
+        )
+        assert resp.buys_executed == 1
+
+
+class TestYieldModels:
+    def test_yield_scan_request_defaults(self):
+        req = m.YieldScanRequest()
+        assert req.min_apy == 0.0
+        assert req.min_tvl == 0.0
+        assert req.category is None
+
+    def test_yield_response(self):
+        resp = m.YieldResponse(
+            protocol="Aave",
+            chain="ethereum",
+            apy=4.5,
+            tvl=1e9,
+            category="lending",
+            token="USDC",
+        )
+        assert resp.protocol == "Aave"
+
+
+class TestBridgeModels:
+    def test_bridge_request(self):
+        req = m.BridgeRequest(
+            from_chain="ethereum", to_chain="arbitrum", token="USDC", amount="100"
+        )
+        assert req.from_address is None
+
+    def test_bridge_request_missing_required(self):
+        with pytest.raises(Exception):
+            m.BridgeRequest(from_chain="ethereum")
+
+    def test_bridge_quote_response(self):
+        resp = m.BridgeQuoteResponse(
+            from_chain="ethereum",
+            to_chain="arbitrum",
+            token="USDC",
+            amount="100",
+            estimated_receive="99",
+            bridge_fee="1",
+            estimated_time="5m",
+            route="lifi",
+        )
+        assert resp.route == "lifi"

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,748 @@
+"""Coverage tests for the API route handlers.
+
+All network/RPC/web3/service layers are mocked so nothing touches the
+network. Exercises both happy paths and error/validation paths for every
+route module under web3_agent_kit/api/routes/.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
+TEST_API_KEY = "test-key-123"
+
+if FASTAPI_AVAILABLE:
+    # Fail-closed startup guard requires WEB3_API_KEY before the app boots.
+    os.environ.setdefault("WEB3_API_KEY", TEST_API_KEY)
+
+    from web3_agent_kit.api import app
+
+    client = TestClient(app)
+    AUTH_HEADERS = {"X-API-Key": TEST_API_KEY}
+
+
+@pytest.fixture(autouse=True)
+def _ensure_api_key(monkeypatch):
+    """Guarantee the known API key is configured for every test."""
+    monkeypatch.setenv("WEB3_API_KEY", TEST_API_KEY)
+
+
+pytestmark = pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
+
+
+# === Wallet routes ===
+
+
+class TestWalletRoutes:
+    def test_info_happy(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            inst = MagicMock()
+            inst.address = "0xabc"
+            inst.get_balance.return_value = 2.0
+            MockWallet.from_env.return_value = inst
+            resp = client.get("/wallet/info", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["address"] == "0xabc"
+            assert data["chain"] == "ethereum"
+            assert data["balance"] == "2.0"
+
+    def test_info_error_path(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            MockWallet.from_env.side_effect = ValueError("no wallet")
+            resp = client.get("/wallet/info", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+            assert "no wallet" in resp.json()["detail"]
+
+    def test_create_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("ENABLE_WALLET_CREATE_ENDPOINT", raising=False)
+        resp = client.post("/wallet/create", headers=AUTH_HEADERS)
+        assert resp.status_code == 403
+
+    def test_create_enabled(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_WALLET_CREATE_ENDPOINT", "true")
+        resp = client.post("/wallet/create", headers=AUTH_HEADERS)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["private_key"].startswith("0x")
+        assert data["address"].startswith("0x")
+        assert data["chain"] == "ethereum"
+
+    def test_create_error_path(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_WALLET_CREATE_ENDPOINT", "true")
+        with patch("eth_account.Account.create", side_effect=RuntimeError("boom")):
+            resp = client.post("/wallet/create", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+            assert "boom" in resp.json()["detail"]
+
+    def test_balance_happy(self):
+        with patch("web3_agent_kit.chains.chain.ChainManager") as MockManager:
+            mgr = MagicMock()
+            w3 = MagicMock()
+            w3.eth.get_balance.return_value = 3_000_000_000_000_000_000
+            w3.from_wei.return_value = 3.0
+            w3.to_checksum_address = lambda a: a
+            mgr.get_web3.return_value = w3
+            MockManager.return_value = mgr
+            resp = client.get("/wallet/balance/0xdead", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["address"] == "0xdead"
+            assert data["balance"] == "3.0"
+            assert data["chain"] == "ethereum"
+
+    def test_balance_unsupported_chain(self):
+        resp = client.get(
+            "/wallet/balance/0xdead?chain=bogus", headers=AUTH_HEADERS
+        )
+        assert resp.status_code == 400
+        assert "Unsupported chain" in resp.json()["detail"]
+
+    def test_balance_solana_path(self):
+        with patch("web3_agent_kit.chains.chain.ChainManager") as MockManager:
+            mgr = MagicMock()
+            sol = MagicMock()
+            resp_obj = MagicMock()
+            resp_obj.value = 5_000_000_000  # 5 SOL in lamports
+            sol.get_balance.return_value = resp_obj
+            mgr.get_solana.return_value = sol
+            MockManager.return_value = mgr
+            resp = client.get(
+                "/wallet/balance/SoLaddr?chain=solana", headers=AUTH_HEADERS
+            )
+            assert resp.status_code == 200
+            assert resp.json()["balance"] == "5.0"
+
+    def test_balance_error_path(self):
+        with patch("web3_agent_kit.chains.chain.ChainManager") as MockManager:
+            MockManager.side_effect = RuntimeError("rpc down")
+            resp = client.get("/wallet/balance/0xdead", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+            assert "rpc down" in resp.json()["detail"]
+
+
+# === Swap routes ===
+
+
+class TestSwapRoutes:
+    def test_quote_happy(self):
+        with patch("web3_agent_kit.defi.Uniswap") as MockUni:
+            inst = MagicMock()
+            inst.get_quote.return_value = {"token_in": "ETH", "estimated_out": "3500"}
+            MockUni.return_value = inst
+            resp = client.get(
+                "/swap/quote?token_in=ETH&token_out=USDC&amount_in=1.0",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["token_in"] == "ETH"
+
+    def test_quote_error(self):
+        with patch("web3_agent_kit.defi.Uniswap") as MockUni:
+            MockUni.side_effect = ValueError("bad token")
+            resp = client.get("/swap/quote", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+            assert "bad token" in resp.json()["detail"]
+
+    def test_execute_happy(self):
+        with patch("web3_agent_kit.defi.Uniswap") as MockUni, patch(
+            "web3_agent_kit.wallet.wallet.Wallet"
+        ) as MockWallet:
+            inst = MagicMock()
+            inst.execute.return_value = {"tx_hash": "0x1", "status": "success"}
+            MockUni.return_value = inst
+            MockWallet.from_env.return_value = MagicMock()
+            resp = client.post(
+                "/swap/execute?token_in=ETH&token_out=USDC&amount_in=1.0",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "success"
+
+    def test_execute_error(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            MockWallet.from_env.side_effect = RuntimeError("no key")
+            resp = client.post("/swap/execute", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+            assert "no key" in resp.json()["detail"]
+
+    def test_tokens_happy(self):
+        with patch("web3_agent_kit.defi.Uniswap") as MockUni:
+            inst = MagicMock()
+            inst.ROUTERS = {"ethereum": "0xrouter"}
+            inst.supported_chains = ["ethereum", "polygon"]
+            MockUni.return_value = inst
+            resp = client.get("/swap/tokens", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["chain"] == "ethereum"
+            assert data["router"] == "0xrouter"
+
+    def test_tokens_error(self):
+        with patch("web3_agent_kit.defi.Uniswap") as MockUni:
+            MockUni.side_effect = RuntimeError("fail")
+            resp = client.get("/swap/tokens", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+
+# === Portfolio routes ===
+
+
+class TestPortfolioRoutes:
+    def test_portfolio_happy(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            inst = MagicMock()
+            inst.address = "0xabc"
+            inst.get_balance.return_value = 1.0
+            MockWallet.from_env.return_value = inst
+            resp = client.get("/portfolio/", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["address"] == "0xabc"
+            assert data["native_balance"] == "1.0"
+
+    def test_portfolio_error(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            MockWallet.from_env.side_effect = RuntimeError("nope")
+            resp = client.get("/portfolio/", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_portfolio_value_happy(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            inst = MagicMock()
+            inst.address = "0xabc"
+            inst.get_balance.return_value = 4.2
+            MockWallet.from_env.return_value = inst
+            resp = client.get("/portfolio/value", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["native_balance"] == "4.2"
+
+    def test_portfolio_value_error(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            MockWallet.from_env.side_effect = RuntimeError("nope")
+            resp = client.get("/portfolio/value", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+
+# === Gas routes ===
+
+
+class TestGasRoutes:
+    def test_estimate_happy(self):
+        with patch("web3_agent_kit.gas.optimizer.GasOptimizer") as MockOpt:
+            inst = MagicMock()
+            inst.estimate.return_value = {"chain": "ethereum", "base_fee": 1}
+            MockOpt.return_value = inst
+            resp = client.get("/gas/estimate", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["chain"] == "ethereum"
+
+    def test_estimate_error(self):
+        with patch("web3_agent_kit.gas.optimizer.GasOptimizer") as MockOpt:
+            MockOpt.side_effect = RuntimeError("gas fail")
+            resp = client.get("/gas/estimate", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_recommendation_happy(self):
+        with patch("web3_agent_kit.gas.optimizer.GasOptimizer") as MockOpt:
+            inst = MagicMock()
+            inst.recommend_timing.return_value = {"action": "wait"}
+            MockOpt.return_value = inst
+            resp = client.get("/gas/recommendation", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["action"] == "wait"
+
+    def test_recommendation_error(self):
+        with patch("web3_agent_kit.gas.optimizer.GasOptimizer") as MockOpt:
+            MockOpt.side_effect = RuntimeError("x")
+            resp = client.get("/gas/recommendation", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_batch_happy(self):
+        with patch("web3_agent_kit.gas.optimizer.GasOptimizer") as MockOpt:
+            inst = MagicMock()
+            inst.batch_estimate.return_value = {"swap": 100}
+            MockOpt.return_value = inst
+            resp = client.get("/gas/batch", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["swap"] == 100
+
+    def test_batch_error(self):
+        with patch("web3_agent_kit.gas.optimizer.GasOptimizer") as MockOpt:
+            MockOpt.side_effect = RuntimeError("x")
+            resp = client.get("/gas/batch", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+
+# === Watcher routes ===
+
+
+class TestWatcherRoutes:
+    def test_list_happy(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            inst = MagicMock()
+            inst.list_wallets.return_value = [{"address": "0x1"}]
+            MockW.return_value = inst
+            resp = client.get("/watcher/list", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["wallets"][0]["address"] == "0x1"
+
+    def test_list_error(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            MockW.side_effect = RuntimeError("fail")
+            resp = client.get("/watcher/list", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_add_happy(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            inst = MagicMock()
+            inst.add_wallet.return_value = {"status": "added"}
+            MockW.return_value = inst
+            resp = client.post(
+                "/watcher/add?address=0x1&label=whale", headers=AUTH_HEADERS
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "added"
+
+    def test_add_missing_required_param(self):
+        resp = client.post("/watcher/add", headers=AUTH_HEADERS)
+        assert resp.status_code == 422
+
+    def test_add_error(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            MockW.side_effect = RuntimeError("fail")
+            resp = client.post("/watcher/add?address=0x1", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_remove_happy(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            inst = MagicMock()
+            inst.remove_wallet.return_value = {"status": "removed"}
+            MockW.return_value = inst
+            resp = client.delete("/watcher/remove?address=0x1", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "removed"
+
+    def test_remove_error(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            MockW.side_effect = RuntimeError("fail")
+            resp = client.delete("/watcher/remove?address=0x1", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_alerts_happy(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            inst = MagicMock()
+            inst.get_alerts.return_value = [{"msg": "hi"}]
+            MockW.return_value = inst
+            resp = client.get("/watcher/alerts?limit=10", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["alerts"][0]["msg"] == "hi"
+
+    def test_alerts_error(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            MockW.side_effect = RuntimeError("fail")
+            resp = client.get("/watcher/alerts", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_check_happy(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            inst = MagicMock()
+            inst.check_all.return_value = {"checked": 2}
+            MockW.return_value = inst
+            resp = client.post("/watcher/check", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["checked"] == 2
+
+    def test_check_error(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            MockW.side_effect = RuntimeError("fail")
+            resp = client.post("/watcher/check", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_summary_happy(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            inst = MagicMock()
+            inst.get_summary.return_value = {"total": 3}
+            MockW.return_value = inst
+            resp = client.get("/watcher/summary", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["total"] == 3
+
+    def test_summary_error(self):
+        with patch("web3_agent_kit.wallet.watcher.WalletWatcher") as MockW:
+            MockW.side_effect = RuntimeError("fail")
+            resp = client.get("/watcher/summary", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+
+# === Approval routes ===
+
+
+class TestApprovalRoutes:
+    def test_scan_happy(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            inst = MagicMock()
+            inst.scan.return_value = [{"token": "USDC"}]
+            MockM.return_value = inst
+            resp = client.get("/approval/scan", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["total"] == 1
+
+    def test_scan_error(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            MockM.side_effect = RuntimeError("fail")
+            resp = client.get("/approval/scan", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_risk_happy(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            inst = MagicMock()
+            inst.get_summary.return_value = {"total_approvals": 2}
+            inst.get_risky.return_value = []
+            inst.get_unlimited.return_value = []
+            MockM.return_value = inst
+            resp = client.get("/approval/risk", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["summary"]["total_approvals"] == 2
+
+    def test_risk_error(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            MockM.side_effect = RuntimeError("fail")
+            resp = client.get("/approval/risk", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_revoke_happy(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            inst = MagicMock()
+            inst.revoke.return_value = {"status": "revoked"}
+            MockM.return_value = inst
+            resp = client.post(
+                "/approval/revoke?token=0xtok&spender=0xspender",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "revoked"
+
+    def test_revoke_error(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            MockM.side_effect = RuntimeError("fail")
+            resp = client.post("/approval/revoke", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_revoke_all_unlimited_happy(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            inst = MagicMock()
+            inst.revoke_all_unlimited.return_value = {"revoked": 3}
+            MockM.return_value = inst
+            resp = client.post("/approval/revoke-all-unlimited", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["revoked"] == 3
+
+    def test_revoke_all_unlimited_error(self):
+        with patch("web3_agent_kit.wallet.approval.ApprovalManager") as MockM:
+            MockM.side_effect = RuntimeError("fail")
+            resp = client.post("/approval/revoke-all-unlimited", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_known_protocols_happy(self):
+        with patch(
+            "web3_agent_kit.wallet.approval.KNOWN_SPENDERS",
+            {"Uniswap V2": "0xrouter"},
+        ):
+            resp = client.get("/approval/known-protocols", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert "Uniswap V2" in resp.json()["protocols"]
+
+
+# === DCA routes ===
+
+
+class TestDCARoutes:
+    def test_list_happy(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.list_orders.return_value = [{"order_id": "d1"}]
+            MockBot.return_value = inst
+            resp = client.get("/dca/orders", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["orders"][0]["order_id"] == "d1"
+
+    def test_list_error(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            MockBot.side_effect = RuntimeError("fail")
+            resp = client.get("/dca/orders", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_create_happy_unlimited(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.create_order.return_value = {"order_id": "d2", "status": "active"}
+            MockBot.return_value = inst
+            resp = client.post(
+                "/dca/orders?token_in=USDC&token_out=ETH&amount_per_buy=100",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            # total_buys defaults 0 -> None passed to create_order
+            _, kwargs = inst.create_order.call_args
+            assert kwargs["total_buys"] is None
+
+    def test_create_happy_with_total_buys(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.create_order.return_value = {"order_id": "d3"}
+            MockBot.return_value = inst
+            resp = client.post(
+                "/dca/orders?amount_per_buy=100&total_buys=5", headers=AUTH_HEADERS
+            )
+            assert resp.status_code == 200
+            _, kwargs = inst.create_order.call_args
+            assert kwargs["total_buys"] == 5
+
+    def test_create_error(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            MockBot.side_effect = RuntimeError("fail")
+            resp = client.post("/dca/orders", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_create_validation_error(self):
+        resp = client.post("/dca/orders?total_buys=notanint", headers=AUTH_HEADERS)
+        assert resp.status_code == 422
+
+    def test_get_order_happy(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.get_order.return_value = {"order_id": "d1", "status": "active"}
+            MockBot.return_value = inst
+            resp = client.get("/dca/orders/d1", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+
+    def test_get_order_not_found(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.get_order.side_effect = KeyError("missing")
+            MockBot.return_value = inst
+            resp = client.get("/dca/orders/nope", headers=AUTH_HEADERS)
+            assert resp.status_code == 404
+
+    def test_cancel_happy(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.cancel_order.return_value = {"status": "cancelled"}
+            MockBot.return_value = inst
+            resp = client.delete("/dca/orders/d1", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+
+    def test_cancel_error(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            MockBot.side_effect = RuntimeError("fail")
+            resp = client.delete("/dca/orders/d1", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_pause_happy(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.pause_order.return_value = {"status": "paused"}
+            MockBot.return_value = inst
+            resp = client.post("/dca/orders/d1/pause", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+
+    def test_pause_error(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            MockBot.side_effect = RuntimeError("fail")
+            resp = client.post("/dca/orders/d1/pause", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_resume_happy(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.resume_order.return_value = {"status": "active"}
+            MockBot.return_value = inst
+            resp = client.post("/dca/orders/d1/resume", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+
+    def test_resume_error(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            MockBot.side_effect = RuntimeError("fail")
+            resp = client.post("/dca/orders/d1/resume", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_stats_happy(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            inst = MagicMock()
+            inst.get_summary.return_value = {"total_orders": 4}
+            MockBot.return_value = inst
+            resp = client.get("/dca/stats", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["total_orders"] == 4
+
+    def test_stats_error(self):
+        with patch("web3_agent_kit.trading.dca.DCABot") as MockBot:
+            MockBot.side_effect = RuntimeError("fail")
+            resp = client.get("/dca/stats", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+
+# === Yield routes ===
+
+
+class TestYieldRoutes:
+    def test_opportunities_happy(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            inst = MagicMock()
+            inst.scan_opportunities.return_value = [{"protocol": "Aave"}]
+            MockO.return_value = inst
+            resp = client.get("/yield/opportunities?min_apy=1.5", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["total"] == 1
+
+    def test_opportunities_error(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            MockO.side_effect = RuntimeError("fail")
+            resp = client.get("/yield/opportunities", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_best_happy(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            inst = MagicMock()
+            inst.find_best.return_value = {"protocol": "Aave", "apy": 5.0}
+            MockO.return_value = inst
+            resp = client.get("/yield/best", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["apy"] == 5.0
+
+    def test_best_error(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            MockO.side_effect = RuntimeError("fail")
+            resp = client.get("/yield/best", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_compare_happy(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            inst = MagicMock()
+            inst.compare_protocols.return_value = [{"protocol": "Aave"}]
+            MockO.return_value = inst
+            resp = client.get("/yield/compare", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+
+    def test_compare_error(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            MockO.side_effect = RuntimeError("fail")
+            resp = client.get("/yield/compare", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_portfolio_happy(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            inst = MagicMock()
+            inst.get_portfolio_summary.return_value = {"total_value": 100}
+            MockO.return_value = inst
+            resp = client.get("/yield/portfolio", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["total_value"] == 100
+
+    def test_portfolio_error(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            MockO.side_effect = RuntimeError("fail")
+            resp = client.get("/yield/portfolio", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_compound_happy(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            inst = MagicMock()
+            inst.auto_compound_all.return_value = {"compounded": 2}
+            MockO.return_value = inst
+            resp = client.post("/yield/compound", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["compounded"] == 2
+
+    def test_compound_error(self):
+        with patch("web3_agent_kit.defi.yield_optimizer.YieldOptimizer") as MockO:
+            MockO.side_effect = RuntimeError("fail")
+            resp = client.post("/yield/compound", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+
+# === Bridge routes ===
+
+
+class TestBridgeRoutes:
+    def test_quote_happy(self):
+        with patch("web3_agent_kit.bridge.bridge.BridgeAgent") as MockA:
+            inst = MagicMock()
+            inst.get_routes.return_value = {"routes": []}
+            MockA.return_value = inst
+            resp = client.get(
+                "/bridge/quote?from_chain=ethereum&to_chain=arbitrum&token=USDC&amount=100",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"routes": []}
+
+    def test_quote_error(self):
+        with patch("web3_agent_kit.bridge.bridge.BridgeAgent") as MockA:
+            MockA.side_effect = RuntimeError("fail")
+            resp = client.get("/bridge/quote", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_execute_happy(self):
+        with patch("web3_agent_kit.bridge.bridge.BridgeAgent") as MockA, patch(
+            "web3_agent_kit.wallet.wallet.Wallet"
+        ) as MockWallet:
+            inst = MagicMock()
+            inst.transfer.return_value = {"tx_hash": "0xbridge"}
+            MockA.return_value = inst
+            MockWallet.from_env.return_value = MagicMock()
+            resp = client.post("/bridge/execute", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            assert resp.json()["tx_hash"] == "0xbridge"
+
+    def test_execute_error(self):
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+            MockWallet.from_env.side_effect = RuntimeError("no key")
+            resp = client.post("/bridge/execute", headers=AUTH_HEADERS)
+            assert resp.status_code == 400
+
+    def test_chains_happy(self):
+        with patch(
+            "web3_agent_kit.bridge.bridge.LIFI_CHAIN_IDS", {"ethereum": 1}
+        ), patch(
+            "web3_agent_kit.bridge.bridge.SOCKET_CHAIN_IDS", {"arbitrum": 42161}
+        ):
+            resp = client.get("/bridge/chains", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "ethereum" in data["lifi_chains"]
+            assert "arbitrum" in data["socket_chains"]
+
+
+# === Auth enforcement across route modules ===
+
+
+class TestAuthEnforcement:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/wallet/info",
+            "/swap/quote",
+            "/portfolio/",
+            "/gas/estimate",
+            "/watcher/list",
+            "/approval/scan",
+            "/dca/orders",
+            "/yield/opportunities",
+            "/bridge/chains",
+        ],
+    )
+    def test_missing_key_rejected(self, path):
+        resp = client.get(path)
+        assert resp.status_code == 401

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,265 @@
+"""Tests for the WAK CLI (web3_agent_kit.cli)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from web3_agent_kit.cli.commands.agent import agent
+from web3_agent_kit.cli.commands.doctor import doctor
+from web3_agent_kit.cli.commands.examples import examples
+from web3_agent_kit.cli.commands.gas import gas
+from web3_agent_kit.cli.commands.info import (
+    _count_chains,
+    _count_modules,
+    _read_version,
+    info,
+)
+from web3_agent_kit.cli.commands.token import token
+from web3_agent_kit.cli.commands.wallet import wallet
+from web3_agent_kit.cli.main import main
+
+runner = CliRunner()
+
+
+# === main group ===
+
+
+class TestMainGroup:
+    def test_no_subcommand_shows_banner_and_help(self):
+        result = runner.invoke(main, [])
+        assert result.exit_code == 0
+        assert "Web3 Agent Kit CLI" in result.output
+        assert "Usage" in result.output
+
+    def test_help(self):
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "WAK" in result.output
+
+    def test_version(self):
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "1.12.0" in result.output
+
+    def test_subcommands_registered(self):
+        result = runner.invoke(main, ["--help"])
+        for cmd in ("info", "doctor", "wallet", "token", "gas", "agent", "examples"):
+            assert cmd in result.output
+
+
+# === info command ===
+
+
+class TestInfoCommand:
+    def test_info_runs(self):
+        result = runner.invoke(info, [])
+        assert result.exit_code == 0
+        assert "web3-agent-kit" in result.output
+        assert "Capabilities" in result.output
+        assert "Links" in result.output
+
+    def test_count_modules(self, tmp_path):
+        pkg = tmp_path / "mymod"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        # dir without __init__ should not count
+        (tmp_path / "nopkg").mkdir()
+        # hidden / underscore dirs skipped
+        hidden = tmp_path / "_private"
+        hidden.mkdir()
+        (hidden / "__init__.py").write_text("")
+        assert _count_modules(str(tmp_path)) == 1
+
+    def test_count_chains(self, tmp_path):
+        chains_dir = tmp_path / "chains"
+        chains_dir.mkdir()
+        (chains_dir / "chain.py").write_text(
+            'class Chain:\n'
+            '    ETHEREUM = "ethereum"\n'
+            '    BASE = "base"\n'
+            '    # COMMENT = "skip"\n'
+        )
+        assert _count_chains(str(tmp_path)) == 2
+
+    def test_count_chains_missing_file(self, tmp_path):
+        assert _count_chains(str(tmp_path)) == 0
+
+    def test_read_version_returns_string(self):
+        version = _read_version()
+        assert isinstance(version, str)
+        assert version != ""
+
+    def test_read_version_missing_pyproject(self):
+        with patch("os.path.isfile", return_value=False):
+            assert _read_version() == "unknown"
+
+    def test_info_through_main(self):
+        result = runner.invoke(main, ["info"])
+        assert result.exit_code == 0
+
+
+# === doctor command ===
+
+
+class TestDoctorCommand:
+    def test_doctor_runs(self):
+        result = runner.invoke(doctor, [])
+        assert result.exit_code == 0
+        assert "WAK Doctor" in result.output
+        assert "Python" in result.output
+
+    def test_doctor_with_env_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("PRIVATE_KEY=0xabc123\n")
+        monkeypatch.setenv("PRIVATE_KEY", "0x1234567890abcdef1234")
+        result = runner.invoke(doctor, [])
+        assert result.exit_code == 0
+        assert ".env file" in result.output
+        # masked private key
+        assert "PRIVATE_KEY" in result.output
+
+    def test_doctor_short_env_masked(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RPC_URL", "short")
+        result = runner.invoke(doctor, [])
+        assert result.exit_code == 0
+        assert "***" in result.output
+
+    def test_doctor_through_main(self):
+        result = runner.invoke(main, ["doctor"])
+        assert result.exit_code == 0
+
+
+# === wallet command ===
+
+
+class TestWalletCommand:
+    def test_wallet_group_help(self):
+        result = runner.invoke(wallet, ["--help"])
+        assert result.exit_code == 0
+        assert "balance" in result.output
+
+    def test_wallet_balance(self):
+        result = runner.invoke(
+            wallet, ["balance", "--address", "0xabc", "--chain", "base"]
+        )
+        assert result.exit_code == 0
+        assert "0xabc" in result.output
+        assert "base" in result.output
+
+    def test_wallet_balance_short_opts(self):
+        result = runner.invoke(wallet, ["balance", "-a", "0xdef"])
+        assert result.exit_code == 0
+        assert "0xdef" in result.output
+
+    def test_wallet_balance_requires_address(self):
+        result = runner.invoke(wallet, ["balance"])
+        assert result.exit_code != 0
+
+
+# === token command ===
+
+
+class TestTokenCommand:
+    def test_token_group_help(self):
+        result = runner.invoke(token, ["--help"])
+        assert result.exit_code == 0
+        assert "check" in result.output
+
+    def test_token_check(self):
+        result = runner.invoke(
+            token, ["check", "--address", "0xtoken", "--chain", "ethereum"]
+        )
+        assert result.exit_code == 0
+        assert "0xtoken" in result.output
+        assert "Token Safety Check" in result.output
+
+    def test_token_check_requires_address(self):
+        result = runner.invoke(token, ["check"])
+        assert result.exit_code != 0
+
+
+# === gas command ===
+
+
+class TestGasCommand:
+    def test_gas_default(self):
+        result = runner.invoke(gas, [])
+        assert result.exit_code == 0
+        assert "Gas Price Estimator" in result.output
+        assert "ethereum" in result.output
+        assert "medium" in result.output
+
+    def test_gas_with_options(self):
+        result = runner.invoke(gas, ["-c", "base", "-p", "high"])
+        assert result.exit_code == 0
+        assert "base" in result.output
+        assert "high" in result.output
+
+    def test_gas_invalid_priority(self):
+        result = runner.invoke(gas, ["-p", "invalid"])
+        assert result.exit_code != 0
+
+
+# === agent command ===
+
+
+class TestAgentCommand:
+    def test_agent_runs(self):
+        result = runner.invoke(
+            agent, ["--goal", "swap ETH", "--wallet", "0x1234", "--chain", "base"]
+        )
+        assert result.exit_code == 0
+        assert "swap ETH" in result.output
+        assert "0x1234" in result.output
+        assert "WAK Agent" in result.output
+
+    def test_agent_requires_goal_and_wallet(self):
+        result = runner.invoke(agent, [])
+        assert result.exit_code != 0
+
+    def test_agent_short_opts(self):
+        result = runner.invoke(agent, ["-g", "bridge", "-w", "0xabc", "-c", "base"])
+        assert result.exit_code == 0
+        assert "bridge" in result.output
+
+
+# === examples command ===
+
+
+class TestExamplesCommand:
+    def test_examples_lists_files(self, tmp_path):
+        examples_dir = tmp_path / "examples"
+        examples_dir.mkdir()
+        (examples_dir / "swap_agent.py").write_text("")
+        (examples_dir / "custom.py").write_text("")
+        (examples_dir / "notpython.txt").write_text("")
+        with patch("os.path.normpath", return_value=str(examples_dir)):
+            result = runner.invoke(examples, [])
+        assert result.exit_code == 0
+        assert "swap_agent.py" in result.output
+        assert "custom.py" in result.output
+        assert "notpython.txt" not in result.output
+
+    def test_examples_dir_missing(self):
+        with patch("os.path.isdir", return_value=False):
+            result = runner.invoke(examples, [])
+        assert result.exit_code == 0
+        assert "Examples directory not found" in result.output
+
+    def test_examples_no_py_files(self, tmp_path):
+        examples_dir = tmp_path / "examples"
+        examples_dir.mkdir()
+        (examples_dir / "readme.txt").write_text("")
+        with patch("os.path.normpath", return_value=str(examples_dir)):
+            result = runner.invoke(examples, [])
+        assert result.exit_code == 0
+        assert "No example files found" in result.output
+
+    def test_examples_real_run(self):
+        # Runs against the real examples dir (may or may not exist); must not crash.
+        result = runner.invoke(examples, [])
+        assert result.exit_code == 0
+        assert "Available Examples" in result.output

--- a/tests/test_messaging_events_gov.py
+++ b/tests/test_messaging_events_gov.py
@@ -1,0 +1,759 @@
+"""Tests for messaging, events, governance, and account_abstraction modules.
+
+All network/RPC calls are mocked — tests are fully offline.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from web3_agent_kit.account_abstraction import (
+    BUNDLER_RPCS,
+    ENTRY_POINTS,
+    KNOWN_FACTORIES,
+    AAPaymaster,
+    AAWallet,
+    UserOperation,
+    UserOpResult,
+)
+from web3_agent_kit.events import (
+    ERC20_TRANSFER_ABI,
+    EventConfig,
+    EventListener,
+    Subscription,
+)
+from web3_agent_kit.governance import (
+    KNOWN_DAOS,
+    DelegateInfo,
+    GovConfig,
+    GovernanceTracker,
+    Proposal,
+    ProposalStatus,
+    VoteChoice,
+    VotingPower,
+)
+from web3_agent_kit.messaging import (
+    CCIP_CHAIN_SELECTORS,
+    LZ_CHAIN_IDS,
+    BridgeProtocol,
+    CrossChainMessenger,
+    MessageResult,
+    MessageStatus,
+)
+
+
+# ----------------------------------------------------------------------------
+# Messaging
+# ----------------------------------------------------------------------------
+class TestMessaging:
+    def test_message_result_to_dict(self):
+        res = MessageResult(tx_hash="0xabc", dst_chain="optimism", src_chain="arbitrum", nonce=3)
+        d = res.to_dict()
+        assert d["tx_hash"] == "0xabc"
+        assert d["dst_chain"] == "optimism"
+        assert d["status"] == "pending"
+        assert d["nonce"] == 3
+
+    def test_init_no_rpc(self):
+        m = CrossChainMessenger(bridge="wormhole", rpc_url="")
+        assert m.w3 is None
+        assert m.bridge == BridgeProtocol.WORMHOLE
+
+    def test_init_with_rpc(self):
+        with patch("web3.Web3") as MockWeb3:
+            MockWeb3.HTTPProvider.return_value = "provider"
+            m = CrossChainMessenger(bridge="layerzero", rpc_url="https://x")
+            assert m.w3 is not None
+
+    def test_send_message_wormhole(self):
+        m = CrossChainMessenger(bridge="wormhole", rpc_url="")
+        res = m.send_message(dst_chain="optimism", dst_address="0xdead", payload="0x")
+        assert res.src_chain == "arbitrum"
+        assert res.estimated_delivery == 300
+
+    def test_send_message_wormhole_unknown_chain(self):
+        m = CrossChainMessenger(bridge="wormhole", rpc_url="")
+        with pytest.raises(ValueError, match="Unknown Wormhole"):
+            m.send_message(dst_chain="nope", dst_address="0xdead")
+
+    def test_send_message_ccip(self):
+        m = CrossChainMessenger(bridge="chainlink_ccip", rpc_url="")
+        res = m.send_message(dst_chain="base", dst_address="0xdead")
+        assert res.estimated_delivery == 600
+
+    def test_send_message_ccip_unknown_chain(self):
+        m = CrossChainMessenger(bridge="chainlink_ccip", rpc_url="")
+        with pytest.raises(ValueError, match="Unknown CCIP"):
+            m.send_message(dst_chain="nope", dst_address="0xdead")
+
+    def test_send_layerzero_unknown_dst(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        m.w3 = MagicMock()
+        with pytest.raises(ValueError, match="Unknown chain"):
+            m.send_message(dst_chain="nope", dst_address="0xdead")
+
+    def test_send_layerzero_no_endpoint(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="", src_chain="fantom")
+        m.w3 = MagicMock()
+        with pytest.raises(ValueError, match="No LayerZero endpoint"):
+            m.send_message(dst_chain="optimism", dst_address="0xdead")
+
+    def test_send_layerzero_read_only(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="", src_chain="arbitrum")
+        w3 = MagicMock()
+        w3.eth.default_account = "0x0000000000000000000000000000000000000001"
+        contract = MagicMock()
+        contract.functions.minDstGasLookup.return_value.call.return_value = 0
+        contract.functions.send.return_value.build_transaction.return_value = {}
+        w3.eth.contract.return_value = contract
+        m.w3 = w3
+        res = m.send_message(
+            dst_chain="optimism",
+            dst_address="0x00000000000000000000000000000000000000ab",
+        )
+        assert res.tx_hash == "0x" + "0" * 64
+        assert res.dst_chain == "optimism"
+
+    def test_send_message_unsupported_bridge(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        m.bridge = BridgeProtocol.HYPERLANE
+        with pytest.raises(ValueError, match="Unsupported bridge"):
+            m.send_message(dst_chain="optimism", dst_address="0xdead")
+
+    def test_track_status_lz_delivered(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"messages": {"status": "DELIVERED"}}
+        with patch("requests.get", return_value=resp):
+            assert m.track_status("0xhash") == MessageStatus.DELIVERED
+
+    def test_track_status_lz_executed(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"messages": {"status": "EXECUTED"}}
+        with patch("requests.get", return_value=resp):
+            assert m.track_status("0xhash") == MessageStatus.EXECUTED
+
+    def test_track_status_lz_failed(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"messages": {"status": "FAILED"}}
+        with patch("requests.get", return_value=resp):
+            assert m.track_status("0xhash") == MessageStatus.FAILED
+
+    def test_track_status_lz_pending(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        resp = MagicMock()
+        resp.status_code = 404
+        with patch("requests.get", return_value=resp):
+            assert m.track_status("0xhash") == MessageStatus.PENDING
+
+    def test_track_status_lz_exception(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        with patch("requests.get", side_effect=RuntimeError("boom")):
+            assert m.track_status("0xhash") == MessageStatus.UNKNOWN
+
+    def test_track_status_wormhole_completed(self):
+        m = CrossChainMessenger(bridge="wormhole", rpc_url="")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"operations": [{"status": "completed"}]}
+        with patch("requests.get", return_value=resp):
+            assert m.track_status("0xhash") == MessageStatus.EXECUTED
+
+    def test_track_status_wormhole_pending(self):
+        m = CrossChainMessenger(bridge="wormhole", rpc_url="")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"operations": []}
+        with patch("requests.get", return_value=resp):
+            assert m.track_status("0xhash") == MessageStatus.PENDING
+
+    def test_track_status_wormhole_exception(self):
+        m = CrossChainMessenger(bridge="wormhole", rpc_url="")
+        with patch("requests.get", side_effect=RuntimeError("boom")):
+            assert m.track_status("0xhash") == MessageStatus.UNKNOWN
+
+    def test_track_status_ccip_unknown(self):
+        m = CrossChainMessenger(bridge="chainlink_ccip", rpc_url="")
+        assert m.track_status("0xhash") == MessageStatus.UNKNOWN
+
+    def test_estimate_fee_layerzero(self):
+        m = CrossChainMessenger(bridge="layerzero", rpc_url="")
+        fee = m.estimate_fee("optimism")
+        assert fee["protocol"] == "layerzero"
+        assert fee["currency"] == "ETH"
+
+    def test_estimate_fee_wormhole(self):
+        m = CrossChainMessenger(bridge="wormhole", rpc_url="")
+        fee = m.estimate_fee("solana")
+        assert fee["protocol"] == "wormhole"
+
+    def test_estimate_fee_other(self):
+        m = CrossChainMessenger(bridge="chainlink_ccip", rpc_url="")
+        fee = m.estimate_fee("base")
+        assert fee["protocol"] == "chainlink_ccip"
+
+    def test_constants(self):
+        assert LZ_CHAIN_IDS["ethereum"] == 101
+        assert CCIP_CHAIN_SELECTORS["base"] > 0
+
+
+# ----------------------------------------------------------------------------
+# Events
+# ----------------------------------------------------------------------------
+class TestEvents:
+    def _abi(self):
+        return ERC20_TRANSFER_ABI
+
+    def test_subscribe_with_callback(self):
+        listener = EventListener(rpc_url="https://x")
+        sub_id = listener.subscribe(
+            address="0xabc", abi=self._abi(), event="Transfer", callback=lambda e: None
+        )
+        assert sub_id in listener._subscriptions
+
+    def test_subscribe_no_callback_no_webhook_raises(self):
+        listener = EventListener(rpc_url="https://x")
+        with pytest.raises(ValueError, match="Either callback or webhook"):
+            listener.subscribe(address="0xabc", abi=self._abi(), event="Transfer")
+
+    def test_subscribe_max_reached(self):
+        listener = EventListener(rpc_url="https://x", max_subscriptions=1)
+        listener.subscribe(address="0xa", abi=self._abi(), event="Transfer", callback=lambda e: None)
+        with pytest.raises(ValueError, match="Max subscriptions"):
+            listener.subscribe(address="0xb", abi=self._abi(), event="Transfer", callback=lambda e: None)
+
+    def test_unsubscribe(self):
+        listener = EventListener(rpc_url="https://x")
+        sub_id = listener.subscribe(
+            address="0xabc", abi=self._abi(), event="Transfer", callback=lambda e: None
+        )
+        assert listener.unsubscribe(sub_id) is True
+        assert listener.unsubscribe(sub_id) is False
+
+    def test_unsubscribe_nonexistent(self):
+        listener = EventListener(rpc_url="https://x")
+        assert listener.unsubscribe("nope") is False
+
+    def test_start_idempotent(self):
+        listener = EventListener(rpc_url="https://x")
+        listener._running = True
+        listener.start()  # returns early because already running
+        assert listener._running is True
+
+    def test_stop(self):
+        listener = EventListener(rpc_url="https://x")
+        listener._running = True
+        listener.stop()
+        assert listener._running is False
+
+    def test_get_status(self):
+        listener = EventListener(rpc_url="https://x")
+        listener.subscribe(
+            address="0xabcdef0123456789", abi=self._abi(), event="Transfer", callback=lambda e: None
+        )
+        status = listener.get_status()
+        assert status["running"] is False
+        assert len(status["subscriptions"]) == 1
+        assert status["subscriptions"][0]["event"] == "Transfer"
+
+    def test_poll_subscription_no_new_blocks(self):
+        listener = EventListener(rpc_url="https://x")
+        sub_id = listener.subscribe(
+            address="0x00000000000000000000000000000000000000ab",
+            abi=self._abi(),
+            event="Transfer",
+            callback=lambda e: None,
+        )
+        sub = listener._subscriptions[sub_id]
+        sub.last_block = 100
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        # current_block equal to last_block -> from_block >= to_block -> return
+        listener._poll_subscription(w3, sub, 100)
+        assert sub.events_processed == 0
+
+    def test_poll_subscription_processes_events(self):
+        received = []
+        listener = EventListener(rpc_url="https://x")
+        sub_id = listener.subscribe(
+            address="0x00000000000000000000000000000000000000ab",
+            abi=self._abi(),
+            event="Transfer",
+            callback=received.append,
+        )
+        sub = listener._subscriptions[sub_id]
+        sub.last_block = 0
+        sub.config.from_block = 0
+
+        event = MagicMock()
+        event.blockNumber = 5
+        event.transactionHash.hex.return_value = "0xdeadbeef"
+        event.args = {"from": "0xa", "to": "0xb", "value": 100}
+        event.logIndex = 2
+
+        contract = MagicMock()
+        contract.events.Transfer.get_logs.return_value = [event]
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        w3.eth.contract.return_value = contract
+
+        listener._poll_subscription(w3, sub, 10)
+        assert sub.events_processed == 1
+        assert received[0]["args"]["value"] == 100
+
+    def test_poll_subscription_callback_error(self):
+        listener = EventListener(rpc_url="https://x")
+
+        def bad_cb(e):
+            raise RuntimeError("callback broke")
+
+        sub_id = listener.subscribe(
+            address="0x00000000000000000000000000000000000000ab",
+            abi=self._abi(),
+            event="Transfer",
+            callback=bad_cb,
+        )
+        sub = listener._subscriptions[sub_id]
+        sub.last_block = 0
+        sub.config.from_block = 0
+
+        event = MagicMock()
+        event.blockNumber = 5
+        event.transactionHash.hex.return_value = "0xdeadbeef"
+        event.args = {"value": 1}
+        event.logIndex = 0
+        contract = MagicMock()
+        contract.events.Transfer.get_logs.return_value = [event]
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        w3.eth.contract.return_value = contract
+
+        # Callback error should be swallowed; event still counted
+        listener._poll_subscription(w3, sub, 10)
+        assert sub.events_processed == 1
+
+    def test_poll_subscription_triggers_webhook(self):
+        listener = EventListener(rpc_url="https://x")
+        sub_id = listener.subscribe(
+            address="0x00000000000000000000000000000000000000ab",
+            abi=self._abi(),
+            event="Transfer",
+            webhook_url="https://hook",
+        )
+        sub = listener._subscriptions[sub_id]
+        sub.last_block = 0
+        sub.config.from_block = 0
+
+        event = MagicMock()
+        event.blockNumber = 5
+        event.transactionHash.hex.return_value = "0xdeadbeef"
+        event.args = {"value": 1}
+        event.logIndex = 0
+        contract = MagicMock()
+        contract.events.Transfer.get_logs.return_value = [event]
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        w3.eth.contract.return_value = contract
+
+        with patch("requests.post") as mock_post:
+            listener._poll_subscription(w3, sub, 10)
+            mock_post.assert_called_once()
+
+    def test_send_webhook_error_swallowed(self):
+        listener = EventListener(rpc_url="https://x")
+        config = EventConfig(
+            address="0xa", abi=self._abi(), event_name="Transfer",
+            callback=lambda e: None, webhook_url="https://hook",
+        )
+        with patch("requests.post", side_effect=RuntimeError("net down")):
+            listener._send_webhook({"x": 1}, config)  # must not raise
+
+    def test_subscription_dataclass(self):
+        cfg = EventConfig(
+            address="0xa", abi=self._abi(), event_name="Transfer", callback=lambda e: None
+        )
+        sub = Subscription(id="s1", config=cfg)
+        assert sub.active is True
+        assert sub.events_processed == 0
+
+
+# ----------------------------------------------------------------------------
+# Governance
+# ----------------------------------------------------------------------------
+class TestGovernance:
+    def _tracker(self):
+        with patch("web3.Web3"):
+            t = GovernanceTracker(rpc_url="https://x")
+        t.w3 = MagicMock()
+        t.w3.to_checksum_address.side_effect = lambda a: a
+        return t
+
+    def test_proposal_to_dict(self):
+        p = Proposal(id="1", title="Test", for_votes=10, against_votes=2)
+        d = p.to_dict()
+        assert d["id"] == "1"
+        assert d["for_votes"] == 10
+        assert d["status"] == "pending"
+
+    def test_gov_config_defaults(self):
+        cfg = GovConfig(rpc_url="https://x")
+        assert "snapshot" in cfg.snapshot_graphql_url
+        assert cfg.cache_ttl == 300
+
+    def test_vote_choice_enum(self):
+        assert VoteChoice.FOR.value == "for"
+        assert VoteChoice.AGAINST.value == "against"
+
+    def test_voting_power_dataclass(self):
+        vp = VotingPower(address="0xa", token="0xt", power=5.0)
+        assert vp.can_vote is True
+
+    def test_delegate_info(self):
+        di = DelegateInfo(address="0xa", name="Alice", voting_power=99.0)
+        assert di.name == "Alice"
+
+    def test_get_active_proposals_no_dao_no_governor(self):
+        t = self._tracker()
+        with pytest.raises(ValueError, match="Either dao name or governor_address"):
+            t.get_active_proposals()
+
+    def test_get_active_proposals_known_dao(self):
+        t = self._tracker()
+        governor = MagicMock()
+        governor.functions.proposalCount.return_value.call.return_value = 2
+        governor.functions.state.return_value.call.return_value = 1  # ACTIVE
+        governor.functions.proposalDeadline.return_value.call.return_value = 12345
+        governor.functions.proposalProposer.return_value.call.return_value = "0xauthor"
+        t.w3.eth.contract.return_value = governor
+        with patch.object(t, "_fetch_snapshot_proposals", return_value=[]):
+            props = t.get_active_proposals(dao="uniswap", limit=2)
+        assert len(props) == 2
+        assert props[0].status == ProposalStatus.ACTIVE
+
+    def test_get_active_proposals_governor_address(self):
+        t = self._tracker()
+        governor = MagicMock()
+        governor.functions.proposalCount.return_value.call.return_value = 1
+        governor.functions.state.return_value.call.return_value = 3  # DEFEATED (skipped)
+        t.w3.eth.contract.return_value = governor
+        props = t.get_active_proposals(governor_address="0xgov", limit=1)
+        assert props == []
+
+    def test_get_active_proposals_contract_error(self):
+        t = self._tracker()
+        governor = MagicMock()
+        governor.functions.proposalCount.return_value.call.side_effect = RuntimeError("rpc down")
+        t.w3.eth.contract.return_value = governor
+        props = t.get_active_proposals(governor_address="0xgov")
+        assert props == []
+
+    def test_fetch_snapshot_proposals(self):
+        t = self._tracker()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "data": {
+                "proposals": [
+                    {
+                        "id": "p1",
+                        "title": "T1",
+                        "body": "body",
+                        "start": 1,
+                        "end": 2,
+                        "state": "active",
+                        "author": "0xa",
+                        "choices": ["yes", "no"],
+                        "scores_total": [3.0],
+                        "quorum": 0,
+                        "link": "http://x",
+                    }
+                ]
+            }
+        }
+        with patch("requests.post", return_value=resp):
+            props = t._fetch_snapshot_proposals("uniswap")
+        assert len(props) == 1
+        assert props[0].title == "T1"
+
+    def test_fetch_snapshot_proposals_non_200(self):
+        t = self._tracker()
+        resp = MagicMock()
+        resp.status_code = 500
+        with patch("requests.post", return_value=resp):
+            assert t._fetch_snapshot_proposals("uniswap") == []
+
+    def test_fetch_snapshot_proposals_exception(self):
+        t = self._tracker()
+        with patch("requests.post", side_effect=RuntimeError("boom")):
+            assert t._fetch_snapshot_proposals("uniswap") == []
+
+    def test_get_voting_power_no_token_no_dao(self):
+        t = self._tracker()
+        with pytest.raises(ValueError, match="Either token or dao"):
+            t.get_voting_power(address="0xa")
+
+    def test_get_voting_power_with_dao(self):
+        t = self._tracker()
+        token = MagicMock()
+        token.functions.balanceOf.return_value.call.return_value = 10 ** 18
+        token.functions.delegates.return_value.call.return_value = (
+            "0x000000000000000000000000000000000000000b"
+        )
+        token.functions.getCurrentVotes.return_value.call.return_value = 5 * 10 ** 18
+        t.w3.eth.contract.return_value = token
+        with patch("web3.Web3.from_wei", side_effect=lambda v, u: v / 10 ** 18):
+            vp = t.get_voting_power(address="0x000000000000000000000000000000000000000a", dao="uniswap")
+        assert vp.power == 5.0
+        assert vp.delegated_to is not None
+        assert vp.can_vote is True
+
+    def test_get_voting_power_fallback_to_balance(self):
+        t = self._tracker()
+        token = MagicMock()
+        token.functions.balanceOf.return_value.call.return_value = 2 * 10 ** 18
+        token.functions.delegates.return_value.call.side_effect = RuntimeError("no delegates")
+        token.functions.getCurrentVotes.return_value.call.side_effect = RuntimeError("no votes")
+        t.w3.eth.contract.return_value = token
+        with patch("web3.Web3.from_wei", side_effect=lambda v, u: v / 10 ** 18):
+            vp = t.get_voting_power(address="0xa", token="0xt")
+        assert vp.power == 2.0
+        assert vp.delegated_to is None
+
+    def test_delegate(self):
+        t = self._tracker()
+        account = MagicMock()
+        account.address = "0xacct"
+        t.w3.eth.account.from_key.return_value = account
+        token = MagicMock()
+        token.functions.delegate.return_value.build_transaction.return_value = {}
+        t.w3.eth.contract.return_value = token
+        signed = MagicMock()
+        signed.raw_transaction = b"raw"
+        t.w3.eth.account.sign_transaction.return_value = signed
+        tx_hash = MagicMock()
+        tx_hash.hex.return_value = "0xdelegatehash"
+        t.w3.eth.send_raw_transaction.return_value = tx_hash
+        result = t.delegate(delegatee="0xdel", token="0xt", private_key="0xkey")
+        assert result == "0xdelegatehash"
+
+    def test_get_delegates_success(self):
+        t = self._tracker()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "delegates": [
+                {"address": "0xa", "name": "A", "votingPower": 100, "delegators": 3}
+            ]
+        }
+        with patch("requests.get", return_value=resp):
+            dels = t.get_delegates("uniswap")
+        assert len(dels) == 1
+        assert dels[0].voting_power == 100.0
+
+    def test_get_delegates_exception(self):
+        t = self._tracker()
+        with patch("requests.get", side_effect=RuntimeError("down")):
+            assert t.get_delegates("uniswap") == []
+
+    def test_get_all_daos(self):
+        t = self._tracker()
+        daos = t.get_all_daos()
+        assert len(daos) == len(KNOWN_DAOS)
+        assert all("governor" in d for d in daos)
+
+
+# ----------------------------------------------------------------------------
+# Account Abstraction
+# ----------------------------------------------------------------------------
+class TestAccountAbstraction:
+    def _wallet(self):
+        with patch("web3.Web3"):
+            w = AAWallet(rpc_url="https://x", chain="base")
+        w.w3 = MagicMock()
+        return w
+
+    def test_constants(self):
+        assert ENTRY_POINTS["ethereum"].startswith("0x")
+        assert "pimlico" in BUNDLER_RPCS["base"]
+        assert "simple_account_v7" in KNOWN_FACTORIES
+
+    def test_user_operation_defaults(self):
+        op = UserOperation(sender="0xa", nonce=0)
+        assert op.call_data == "0x"
+        assert op.signature == "0x"
+
+    def test_user_op_result(self):
+        r = UserOpResult(user_op_hash="0xh")
+        assert r.status == "pending"
+
+    def test_wallet_init_defaults(self):
+        w = self._wallet()
+        assert w.factory_address == KNOWN_FACTORIES["simple_account_v7"]
+        assert w.entry_point == ENTRY_POINTS["base"]
+
+    def test_wallet_init_unknown_chain_falls_back(self):
+        with patch("web3.Web3"):
+            w = AAWallet(rpc_url="https://x", chain="unknownchain")
+        assert w.entry_point == ENTRY_POINTS["ethereum"]
+        assert w.bundler_url == "https://x"
+
+    def test_get_counterfactual_address(self):
+        w = self._wallet()
+        with patch.object(w, "_encode_init_code", return_value="0x1234"):
+            from web3 import Web3
+            with patch("web3.Web3.keccak", return_value=b"\x00" * 32), \
+                 patch("web3.Web3.to_bytes", side_effect=lambda *a, **k: b"\x00" * 20), \
+                 patch("web3.Web3.to_checksum_address", side_effect=lambda a: a):
+                addr = w.get_counterfactual_address(owner="0xowner")
+        assert isinstance(addr, str)
+        assert Web3  # imported
+
+    def test_deploy_account_not_deployed(self):
+        w = self._wallet()
+        w.w3.eth.get_code.return_value = b"\x00"  # len <= 2
+        with patch.object(w, "get_counterfactual_address", return_value="0xcf"):
+            info = w.deploy_account(owner="0xowner")
+        assert info.deployed is False
+        assert info.address == "0xcf"
+
+    def test_deploy_account_already_deployed(self):
+        w = self._wallet()
+        w.w3.eth.get_code.return_value = b"\x60\x60\x60"  # len > 2
+        with patch.object(w, "get_counterfactual_address", return_value="0xcf"):
+            info = w.deploy_account(owner="0xowner")
+        assert info.deployed is True
+
+    def test_send_user_op_no_sender_no_owner(self):
+        w = self._wallet()
+        with pytest.raises(ValueError, match="Either sender or owner"):
+            w.send_user_op(to="0xdest")
+
+    def test_send_user_op_with_sender(self):
+        w = self._wallet()
+        w.w3.eth.chain_id = 8453
+        w.w3.eth.gas_price = 1_000_000_000
+        w.w3.eth.get_code.return_value = b"\x60\x60"  # deployed
+        with patch.object(w, "_submit_to_bundler", return_value="0xuohash"):
+            res = w.send_user_op(to="0xdest", sender="0xsender", value=0)
+        assert res.user_op_hash == "0xuohash"
+        assert res.status == "pending"
+
+    def test_send_user_op_with_owner_needs_deploy(self):
+        w = self._wallet()
+        w.w3.eth.chain_id = 8453
+        w.w3.eth.gas_price = 1_000_000_000
+        w.w3.eth.get_code.return_value = b"\x00"  # not deployed
+        with patch.object(w, "get_counterfactual_address", return_value="0xsender"), \
+             patch.object(w, "_encode_init_code", return_value="0xinit"), \
+             patch.object(w, "_submit_to_bundler", return_value="0xuohash"):
+            res = w.send_user_op(to="0xdest", owner="0xowner")
+        assert res.user_op_hash == "0xuohash"
+
+    def test_send_user_op_with_paymaster(self):
+        pm = MagicMock()
+        pm.get_paymaster_data.return_value = {
+            "paymasterAndData": "0xpm", "verificationGasLimit": 600000
+        }
+        w = self._wallet()
+        w.paymaster = pm
+        w.w3.eth.chain_id = 8453
+        w.w3.eth.gas_price = 1_000_000_000
+        w.w3.eth.get_code.return_value = b"\x60\x60"
+        with patch.object(w, "_submit_to_bundler", return_value="0xuohash"):
+            res = w.send_user_op(to="0xdest", sender="0xsender")
+        assert res.user_op_hash == "0xuohash"
+        pm.get_paymaster_data.assert_called_once()
+
+    def test_submit_to_bundler_success(self):
+        w = self._wallet()
+        op = UserOperation(sender="0xa", nonce=0)
+        resp = MagicMock()
+        resp.json.return_value = {"result": "0xuoh"}
+        with patch("requests.post", return_value=resp):
+            assert w._submit_to_bundler(op) == "0xuoh"
+
+    def test_submit_to_bundler_with_api_key(self):
+        with patch("web3.Web3"):
+            w = AAWallet(rpc_url="https://x", chain="base", api_key="secret")
+        w.w3 = MagicMock()
+        op = UserOperation(sender="0xa", nonce=0)
+        resp = MagicMock()
+        resp.json.return_value = {"result": "0xuoh"}
+        with patch("requests.post", return_value=resp) as mock_post:
+            assert w._submit_to_bundler(op) == "0xuoh"
+            headers = mock_post.call_args.kwargs["headers"]
+            assert "Authorization" in headers
+
+    def test_submit_to_bundler_error(self):
+        w = self._wallet()
+        op = UserOperation(sender="0xa", nonce=0)
+        resp = MagicMock()
+        resp.json.return_value = {"error": {"message": "bad op"}}
+        with patch("requests.post", return_value=resp):
+            with pytest.raises(ValueError, match="Bundler error"):
+                w._submit_to_bundler(op)
+
+    def test_get_account_info(self):
+        w = self._wallet()
+        w.w3.eth.get_code.return_value = b"\x60\x60\x60"
+        w.w3.eth.get_balance.return_value = 10 ** 18
+        w.w3.from_wei.return_value = 1.0
+        info = w.get_account_info("0xacct")
+        assert info.deployed is True
+        assert info.balance == 1.0
+
+
+class TestAAPaymaster:
+    def test_get_paymaster_data_default(self):
+        pm = AAPaymaster(paymaster_type="unknown")
+        op = UserOperation(sender="0xa", nonce=0, verification_gas_limit=1000)
+        data = pm.get_paymaster_data(op, "0xep", 1)
+        assert data["paymasterAndData"] == "0x"
+        assert data["verificationGasLimit"] == 1000
+
+    def test_token_paymaster(self):
+        pm = AAPaymaster(paymaster_type="token")
+        op = UserOperation(sender="0xa", nonce=0, verification_gas_limit=2000)
+        data = pm.get_paymaster_data(op, "0xep", 1)
+        assert data["verificationGasLimit"] == 2000
+
+    def test_verifying_paymaster_missing_config(self):
+        pm = AAPaymaster(paymaster_type="verifying")
+        op = UserOperation(sender="0xa", nonce=0)
+        with pytest.raises(ValueError, match="URL and API key required"):
+            pm.get_paymaster_data(op, "0xep", 1)
+
+    def test_verifying_paymaster_success(self):
+        pm = AAPaymaster(
+            paymaster_type="verifying", url="https://pm", api_key="k", policy_id="p1"
+        )
+        op = UserOperation(sender="0xa", nonce=0)
+        resp = MagicMock()
+        resp.json.return_value = {
+            "result": {"paymasterAndData": "0xpmdata", "verificationGasLimit": "0x186a0"}
+        }
+        with patch("requests.post", return_value=resp) as mock_post:
+            data = pm.get_paymaster_data(op, "0xep", 1)
+            # policy id was injected into params
+            sent = mock_post.call_args.kwargs["json"]
+            assert sent["params"][0]["sponsorshipPolicyId"] == "p1"
+        assert data["paymasterAndData"] == "0xpmdata"
+        assert data["verificationGasLimit"] == 100000
+
+    def test_verifying_paymaster_error(self):
+        pm = AAPaymaster(paymaster_type="verifying", url="https://pm", api_key="k")
+        op = UserOperation(sender="0xa", nonce=0)
+        resp = MagicMock()
+        resp.json.return_value = {"error": {"message": "no policy"}}
+        with patch("requests.post", return_value=resp):
+            with pytest.raises(ValueError, match="Paymaster error"):
+                pm.get_paymaster_data(op, "0xep", 1)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_portfolio_tracker.py
+++ b/tests/test_portfolio_tracker.py
@@ -1,0 +1,209 @@
+"""Tests for the portfolio tracker — fully offline, all RPC calls mocked."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from web3_agent_kit.chains.chain import Chain
+from web3_agent_kit.portfolio.tracker import (
+    ChainPortfolio,
+    PortfolioSummary,
+    PortfolioTracker,
+    TokenBalance,
+)
+
+
+def _make_tracker(native_balance=1.0, chains=None):
+    chain_manager = MagicMock()
+    chain_manager.list_chains.return_value = chains or [Chain.ETHEREUM]
+    wallet = MagicMock()
+    wallet.address = "0x00000000000000000000000000000000000000ab"
+    wallet.get_balance.return_value = native_balance
+    return PortfolioTracker(chain_manager, wallet, eth_price=3500.0), chain_manager, wallet
+
+
+class TestDataclasses:
+    def test_token_balance_to_dict(self):
+        tb = TokenBalance(
+            symbol="USDC",
+            address="0xusdc",
+            balance=100.0,
+            decimals=6,
+            chain=Chain.ETHEREUM,
+            price_usd=1.0,
+            value_usd=100.0,
+        )
+        d = tb.to_dict()
+        assert d["symbol"] == "USDC"
+        assert d["chain"] == "ethereum"
+        assert d["value_usd"] == 100.0
+
+    def test_chain_portfolio_to_dict(self):
+        cp = ChainPortfolio(
+            chain=Chain.BASE,
+            native_balance=2.0,
+            native_value_usd=7000.0,
+            tokens=[],
+            total_value_usd=7000.0,
+        )
+        d = cp.to_dict()
+        assert d["chain"] == "base"
+        assert d["tokens"] == []
+
+    def test_portfolio_summary_to_dict_and_str(self):
+        tb = TokenBalance(
+            symbol="USDC", address="0xusdc", balance=50.0, decimals=6,
+            chain=Chain.ETHEREUM, price_usd=1.0, value_usd=50.0,
+        )
+        cp = ChainPortfolio(
+            chain=Chain.ETHEREUM, native_balance=1.0, native_value_usd=3500.0,
+            tokens=[tb], total_value_usd=3550.0,
+        )
+        summary = PortfolioSummary(
+            address="0x00000000000000000000000000000000000000ab",
+            timestamp=123.0,
+            chains=[cp],
+            total_value_usd=3550.0,
+            total_native_balances={"ethereum": 1.0},
+        )
+        d = summary.to_dict()
+        assert d["total_value_usd"] == 3550.0
+        assert len(d["chains"]) == 1
+        text = str(summary)
+        assert "Portfolio" in text
+        assert "USDC" in text
+        assert "ETHEREUM" in text
+
+
+class TestPortfolioTracker:
+    def test_repr(self):
+        tracker, _, _ = _make_tracker()
+        assert "PortfolioTracker" in repr(tracker)
+
+    def test_get_token_balance_success(self):
+        tracker, cm, _ = _make_tracker()
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        contract = MagicMock()
+        contract.functions.balanceOf.return_value.call.return_value = 100 * 10 ** 6
+        contract.functions.decimals.return_value.call.return_value = 6
+        contract.functions.symbol.return_value.call.return_value = "USDC"
+        w3.eth.contract.return_value = contract
+        cm.get_web3.return_value = w3
+
+        tb = tracker._get_token_balance("0xusdc", Chain.ETHEREUM)
+        assert tb is not None
+        assert tb.symbol == "USDC"
+        assert tb.balance == 100.0
+
+    def test_get_token_balance_error_returns_none(self):
+        tracker, cm, _ = _make_tracker()
+        cm.get_web3.side_effect = RuntimeError("rpc down")
+        assert tracker._get_token_balance("0xusdc", Chain.ETHEREUM) is None
+
+    def test_get_chain_portfolio_with_tokens(self):
+        tracker, cm, _ = _make_tracker(native_balance=1.0)
+
+        # Patch _get_token_balance to return a USDC balance only
+        def token_balance(addr, chain):
+            if addr == "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+                return TokenBalance(
+                    symbol="USDC", address=addr, balance=200.0, decimals=6, chain=chain
+                )
+            return None
+
+        tracker._get_token_balance = token_balance
+        cp = tracker._get_chain_portfolio(Chain.ETHEREUM)
+        assert cp.native_balance == 1.0
+        assert cp.native_value_usd == 3500.0
+        # USDC valued at $1 => 200 USD plus native
+        assert cp.total_value_usd == pytest.approx(3700.0)
+        assert any(t.symbol == "USDC" for t in cp.tokens)
+
+    def test_get_chain_portfolio_weth_and_wbtc_and_unknown(self):
+        tracker, cm, _ = _make_tracker(native_balance=0.0)
+
+        def token_balance(addr, chain):
+            mapping = {
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": ("WETH", 2.0),
+                "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": ("WBTC", 0.5),
+                "0x514910771AF9Ca656af840dff83E8264EcF986CA": ("LINK", 100.0),
+            }
+            if addr in mapping:
+                sym, bal = mapping[addr]
+                return TokenBalance(symbol=sym, address=addr, balance=bal, decimals=18, chain=chain)
+            return None
+
+        tracker._get_token_balance = token_balance
+        cp = tracker._get_chain_portfolio(Chain.ETHEREUM)
+        syms = {t.symbol: t for t in cp.tokens}
+        assert syms["WETH"].value_usd == pytest.approx(2.0 * 3500.0)
+        assert syms["WBTC"].value_usd == pytest.approx(0.5 * 60000.0)
+        # LINK has unknown price -> 0
+        assert syms["LINK"].value_usd == 0.0
+
+    def test_get_chain_portfolio_token_exception_skipped(self):
+        tracker, cm, _ = _make_tracker(native_balance=1.0)
+
+        def token_balance(addr, chain):
+            raise RuntimeError("token call failed")
+
+        tracker._get_token_balance = token_balance
+        cp = tracker._get_chain_portfolio(Chain.ETHEREUM)
+        # Only native counts; tokens all errored
+        assert cp.tokens == []
+        assert cp.total_value_usd == 3500.0
+
+    def test_get_summary_default_chains(self):
+        tracker, cm, _ = _make_tracker(native_balance=1.0, chains=[Chain.ETHEREUM])
+        tracker._get_token_balance = lambda addr, chain: None
+        summary = tracker.get_summary()
+        assert summary.total_value_usd == 3500.0
+        assert "ethereum" in summary.total_native_balances
+        assert len(tracker.get_history()) == 1
+
+    def test_get_summary_explicit_chains(self):
+        tracker, cm, _ = _make_tracker(native_balance=1.0)
+        tracker._get_token_balance = lambda addr, chain: None
+        summary = tracker.get_summary(chains=[Chain.ETHEREUM, Chain.BASE])
+        assert len(summary.chains) == 2
+
+    def test_get_summary_chain_error_logged(self):
+        tracker, cm, wallet = _make_tracker()
+        wallet.get_balance.side_effect = RuntimeError("chain broke")
+        summary = tracker.get_summary(chains=[Chain.ETHEREUM])
+        # Chain failed => no chain portfolios but summary still produced
+        assert summary.chains == []
+        assert summary.total_value_usd == 0.0
+
+    def test_get_pnl_insufficient_history(self):
+        tracker, _, _ = _make_tracker()
+        pnl = tracker.get_pnl()
+        assert pnl == {"pnl_absolute": 0.0, "pnl_percent": 0.0}
+
+    def test_get_pnl_with_history(self):
+        tracker, cm, wallet = _make_tracker()
+        tracker._get_token_balance = lambda addr, chain: None
+        # First snapshot at 1 ETH
+        wallet.get_balance.return_value = 1.0
+        tracker.get_summary(chains=[Chain.ETHEREUM])
+        # Second snapshot at 2 ETH
+        wallet.get_balance.return_value = 2.0
+        tracker.get_summary(chains=[Chain.ETHEREUM])
+        pnl = tracker.get_pnl()
+        assert pnl["pnl_absolute"] == pytest.approx(3500.0)
+        assert pnl["pnl_percent"] == pytest.approx(100.0)
+
+    def test_get_pnl_zero_initial(self):
+        tracker, cm, wallet = _make_tracker()
+        tracker._get_token_balance = lambda addr, chain: None
+        wallet.get_balance.return_value = 0.0
+        tracker.get_summary(chains=[Chain.ETHEREUM])
+        wallet.get_balance.return_value = 1.0
+        tracker.get_summary(chains=[Chain.ETHEREUM])
+        pnl = tracker.get_pnl()
+        assert pnl["pnl_percent"] == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_trading_bridge_extra.py
+++ b/tests/test_trading_bridge_extra.py
@@ -1,0 +1,434 @@
+"""Extra tests for TokenSniper and BridgeAgent — mocked chain/RPC/HTTP."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from web3_agent_kit.bridge.bridge import (
+    NATIVE,
+    WETH,
+    BridgeAgent,
+    BridgeRoute,
+)
+from web3_agent_kit.chains.chain import Chain
+from web3_agent_kit.trading.sniper import (
+    FACTORIES,
+    RiskLevel,
+    SniperConfig,
+    TokenSniper,
+)
+
+WETH_ETH = WETH[Chain.ETHEREUM]
+WETH_BASE = WETH[Chain.BASE]
+
+
+def _mock_w3(reserves=(10**18, 500), block_number=1000, code=b"\x60" * 2000):
+    """Build a mocked web3 whose contracts return canned values."""
+    w3 = MagicMock()
+    w3.to_checksum_address.side_effect = lambda a: a
+    w3.from_wei.side_effect = lambda wei, _: wei / 10**18
+    w3.eth.block_number = block_number
+    w3.eth.get_code.return_value = code
+
+    pair_contract = MagicMock()
+    pair_contract.functions.getReserves.return_value.call.return_value = list(
+        reserves
+    ) + [0]
+    pair_contract.functions.token0.return_value.call.return_value = WETH_BASE
+
+    token_contract = MagicMock()
+    token_contract.functions.name.return_value.call.return_value = "Test Token"
+    token_contract.functions.symbol.return_value.call.return_value = "TT"
+
+    factory_contract = MagicMock()
+
+    def _contract(address=None, abi=None):
+        # Distinguish contract types by ABI content
+        names = [item.get("name") for item in abi]
+        if "PairCreated" in names:
+            return factory_contract
+        if "getReserves" in names:
+            return pair_contract
+        return token_contract
+
+    w3.eth.contract.side_effect = _contract
+    return w3, factory_contract, pair_contract, token_contract
+
+
+class TestSniperScan:
+    def test_scan_unsupported_chain(self):
+        sniper = TokenSniper(MagicMock(), MagicMock())
+        with pytest.raises(ValueError, match="Factory not configured"):
+            sniper.scan_recent_blocks(chain=Chain.SOLANA)
+
+    def test_scan_no_events(self):
+        cm = MagicMock()
+        w3, factory, _, _ = _mock_w3()
+        factory.events.PairCreated.get_logs.return_value = []
+        cm.get_web3.return_value = w3
+        sniper = TokenSniper(cm, MagicMock())
+        assert sniper.scan_recent_blocks(chain=Chain.BASE) == []
+
+    def test_scan_with_event(self):
+        cm = MagicMock()
+        w3, factory, _, _ = _mock_w3(reserves=(5 * 10**18, 1000))
+        event = MagicMock()
+        event.args.pair = "0xPAIR"
+        event.args.token0 = WETH_BASE
+        event.args.token1 = "0xTOKEN"
+        event.blockNumber = 999
+        factory.events.PairCreated.get_logs.return_value = [event]
+        cm.get_web3.return_value = w3
+        sniper = TokenSniper(cm, MagicMock(), SniperConfig(auto_buy=False))
+        pairs = sniper.scan_recent_blocks(chain=Chain.BASE)
+        assert len(pairs) == 1
+        assert pairs[0].token_symbol == "TT"
+        assert pairs[0].liquidity_eth == 5.0
+        assert len(sniper.detected_pairs) == 1
+
+
+class TestSniperAnalyze:
+    def test_analyze_skips_non_weth(self):
+        cm = MagicMock()
+        w3, *_ = _mock_w3()
+        cm.get_web3.return_value = w3
+        sniper = TokenSniper(cm, MagicMock())
+        result = sniper._analyze_pair(
+            "0xPAIR", "0xAAA", "0xBBB", Chain.BASE, 1
+        )
+        assert result is None
+
+    def test_analyze_reserves_error(self):
+        cm = MagicMock()
+        w3, _, pair, _ = _mock_w3()
+        pair.functions.getReserves.return_value.call.side_effect = RuntimeError(
+            "boom"
+        )
+        cm.get_web3.return_value = w3
+        sniper = TokenSniper(cm, MagicMock())
+        result = sniper._analyze_pair(
+            "0xPAIR", WETH_BASE, "0xTOKEN", Chain.BASE, 1
+        )
+        assert result is None
+
+    def test_analyze_token_meta_fallback(self):
+        cm = MagicMock()
+        w3, _, _, token = _mock_w3()
+        token.functions.name.return_value.call.side_effect = RuntimeError("x")
+        cm.get_web3.return_value = w3
+        sniper = TokenSniper(cm, MagicMock())
+        result = sniper._analyze_pair(
+            "0xPAIR", WETH_BASE, "0xTOKEN", Chain.BASE, 1
+        )
+        assert result.token_symbol == "???"
+        assert result.token_name == "Unknown"
+
+    def test_analyze_blacklisted(self):
+        cm = MagicMock()
+        w3, *_ = _mock_w3()
+        cm.get_web3.return_value = w3
+        config = SniperConfig(blacklisted_tokens=["0xTOKEN"])
+        sniper = TokenSniper(cm, MagicMock(), config)
+        result = sniper._analyze_pair(
+            "0xPAIR", WETH_BASE, "0xTOKEN", Chain.BASE, 1
+        )
+        assert result is None
+
+
+class TestSniperRisk:
+    def _sniper(self, code=b"\x60" * 2000):
+        cm = MagicMock()
+        w3, *_ = _mock_w3(code=code)
+        cm.get_web3.return_value = w3
+        return TokenSniper(cm, MagicMock())
+
+    def test_low_risk_high_liquidity(self):
+        sniper = self._sniper()
+        risk, score = sniper._assess_risk("0xT", 5.0, Chain.BASE)
+        # 50 + 15 (liq) + 10 (code) + 5 (honeypot) = 80 -> LOW
+        assert risk == RiskLevel.LOW
+        assert score == 80.0
+
+    def test_scam_low_liquidity_tiny_code(self):
+        sniper = self._sniper(code=b"\x00" * 10)
+        risk, score = sniper._assess_risk("0xT", 0.001, Chain.BASE)
+        # 50 - 30 - 40 + 5 = -15 -> SCAM
+        assert risk == RiskLevel.SCAM
+
+    def test_code_fetch_error(self):
+        cm = MagicMock()
+        w3, *_ = _mock_w3()
+        w3.eth.get_code.side_effect = RuntimeError("x")
+        cm.get_web3.return_value = w3
+        sniper = TokenSniper(cm, MagicMock())
+        risk, score = sniper._assess_risk("0xT", 5.0, Chain.BASE)
+        # 50 + 15 - 20 + 5 = 50 -> MEDIUM
+        assert risk == RiskLevel.MEDIUM
+
+
+class TestSniperBuy:
+    def test_buy_no_uniswap(self):
+        sniper = TokenSniper(MagicMock(), MagicMock())
+        from web3_agent_kit.trading.sniper import NewPair
+        pair = NewPair("0xP", WETH_BASE, "0xT", Chain.BASE, 0, RiskLevel.LOW)
+        assert sniper.buy(pair) is None
+
+    def test_buy_success(self):
+        uni = MagicMock()
+        uni.execute.return_value.tx_hash = "0xTX"
+        sniper = TokenSniper(MagicMock(), MagicMock(), uniswap=uni)
+        from web3_agent_kit.trading.sniper import NewPair
+        pair = NewPair("0xP", WETH_BASE, "0xT", Chain.BASE, 0, RiskLevel.LOW)
+        assert sniper.buy(pair) == "0xTX"
+
+    def test_buy_failure(self):
+        uni = MagicMock()
+        uni.execute.side_effect = RuntimeError("swap failed")
+        sniper = TokenSniper(MagicMock(), MagicMock(), uniswap=uni)
+        from web3_agent_kit.trading.sniper import NewPair
+        pair = NewPair("0xP", WETH_BASE, "0xT", Chain.BASE, 0, RiskLevel.LOW)
+        assert sniper.buy(pair) is None
+
+    def test_repr_lists_factories(self):
+        sniper = TokenSniper(MagicMock(), MagicMock())
+        r = repr(sniper)
+        assert "TokenSniper" in r
+        for chain in FACTORIES:
+            assert chain.value in r
+
+
+# ─── Bridge ──────────────────────────────────────────────────────
+
+
+def _bridge(wallet_addr="0xWALLET"):
+    cm = MagicMock()
+    wallet = MagicMock()
+    wallet.address = wallet_addr
+    return BridgeAgent(cm, wallet), cm, wallet
+
+
+class TestBridgeResolveDecimals:
+    def test_resolve_native(self):
+        agent, *_ = _bridge()
+        assert agent._resolve_token("ETH", Chain.ETHEREUM) == NATIVE
+        assert agent._resolve_token("MATIC", Chain.POLYGON) == NATIVE
+
+    def test_resolve_weth(self):
+        agent, *_ = _bridge()
+        assert agent._resolve_token("WETH", Chain.BASE) == WETH_BASE
+
+    def test_resolve_known_token(self):
+        agent, *_ = _bridge()
+        result = agent._resolve_token("USDC", Chain.ETHEREUM)
+        assert result.startswith("0x")
+
+    def test_resolve_unknown_returns_input(self):
+        agent, *_ = _bridge()
+        assert agent._resolve_token("0xCUSTOM", Chain.ETHEREUM) == "0XCUSTOM"
+
+    def test_get_decimals_native(self):
+        agent, *_ = _bridge()
+        assert agent._get_decimals(NATIVE, Chain.ETHEREUM) == 18
+
+    def test_get_decimals_token(self):
+        agent, cm, _ = _bridge()
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        w3.eth.contract.return_value.functions.decimals.return_value.call.return_value = 6
+        cm.get_web3.return_value = w3
+        assert agent._get_decimals("0xUSDC", Chain.ETHEREUM) == 6
+
+    def test_get_decimals_error_default(self):
+        agent, cm, _ = _bridge()
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        w3.eth.contract.return_value.functions.decimals.return_value.call.side_effect = RuntimeError(
+            "x"
+        )
+        cm.get_web3.return_value = w3
+        assert agent._get_decimals("0xUSDC", Chain.ETHEREUM) == 18
+
+
+class TestBridgeRoutes:
+    def test_lifi_unsupported_chain(self):
+        agent, *_ = _bridge()
+        assert agent._get_lifi_routes(
+            "ETH", 1.0, Chain.SOLANA, Chain.BASE
+        ) == []
+
+    def test_socket_unsupported_chain(self):
+        agent, *_ = _bridge()
+        assert agent._get_socket_routes(
+            "ETH", 1.0, Chain.SOLANA, Chain.BASE
+        ) == []
+
+    def test_lifi_routes_parsed(self):
+        agent, *_ = _bridge()
+        resp = MagicMock()
+        resp.json.return_value = {
+            "routes": [
+                {
+                    "toAmount": str(99 * 10**16),
+                    "tags": ["fast"],
+                    "gasCostUSD": "3.5",
+                    "duration": 200,
+                    "steps": [],
+                }
+            ]
+        }
+        agent.session.get = MagicMock(return_value=resp)
+        routes = agent._get_lifi_routes("ETH", 1.0, Chain.ETHEREUM, Chain.BASE)
+        assert len(routes) == 1
+        assert routes[0].bridge_name == "fast"
+        assert routes[0].amount_out == 0.99
+
+    def test_socket_routes_parsed(self):
+        agent, *_ = _bridge()
+        resp = MagicMock()
+        resp.json.return_value = {
+            "result": {
+                "routes": [
+                    {
+                        "toAmount": str(98 * 10**16),
+                        "bridgeName": "hop",
+                        "gasFees": {"gasAmountUSD": "1.2"},
+                        "serviceTime": 150,
+                    }
+                ]
+            }
+        }
+        agent.session.get = MagicMock(return_value=resp)
+        routes = agent._get_socket_routes(
+            "ETH", 1.0, Chain.ETHEREUM, Chain.BASE
+        )
+        assert len(routes) == 1
+        assert routes[0].bridge_name == "hop"
+        assert routes[0].amount_out == 0.98
+
+    def test_get_routes_aggregates_and_sorts(self):
+        agent, *_ = _bridge()
+        r_lo = BridgeRoute(
+            "a", Chain.ETHEREUM, Chain.BASE, "0x", "0x", 1.0, 0.9, 1, 10, 1, []
+        )
+        r_hi = BridgeRoute(
+            "b", Chain.ETHEREUM, Chain.BASE, "0x", "0x", 1.0, 0.99, 1, 10, 1, []
+        )
+        agent._get_lifi_routes = MagicMock(return_value=[r_lo])
+        agent._get_socket_routes = MagicMock(return_value=[r_hi])
+        routes = agent.get_routes("ETH", 1.0, Chain.ETHEREUM, Chain.BASE)
+        assert [r.amount_out for r in routes] == [0.99, 0.9]
+
+    def test_get_routes_handles_provider_errors(self):
+        agent, *_ = _bridge()
+        agent._get_lifi_routes = MagicMock(side_effect=RuntimeError("lifi down"))
+        agent._get_socket_routes = MagicMock(
+            side_effect=RuntimeError("socket down")
+        )
+        assert agent.get_routes("ETH", 1.0, Chain.ETHEREUM, Chain.BASE) == []
+
+
+class TestBridgeTransfer:
+    def _route(self, name):
+        return BridgeRoute(
+            name, Chain.ETHEREUM, Chain.BASE, NATIVE, NATIVE, 0.1, 0.099,
+            2.0, 300, 2.0, [],
+        )
+
+    def test_transfer_no_routes(self):
+        agent, *_ = _bridge()
+        agent.get_routes = MagicMock(return_value=[])
+        with pytest.raises(ValueError, match="No bridge routes"):
+            agent.transfer("ETH", 0.1, Chain.ETHEREUM, Chain.BASE)
+
+    def test_transfer_picks_best_and_routes_lifi(self):
+        agent, *_ = _bridge()
+        route = self._route("Li.Fi")
+        agent.get_routes = MagicMock(return_value=[route])
+        agent._execute_lifi = MagicMock(return_value="lifi-result")
+        assert agent.transfer(
+            "ETH", 0.1, Chain.ETHEREUM, Chain.BASE
+        ) == "lifi-result"
+
+    def test_transfer_routes_socket_default(self):
+        agent, *_ = _bridge()
+        route = self._route("hop")
+        agent._execute_socket = MagicMock(return_value="socket-result")
+        assert agent.transfer(
+            "ETH", 0.1, Chain.ETHEREUM, Chain.BASE, route=route
+        ) == "socket-result"
+
+    def test_execute_lifi(self):
+        agent, cm, _ = _bridge()
+        resp = MagicMock()
+        resp.json.return_value = {
+            "transactionRequest": {
+                "to": "0xTO",
+                "data": "0xdata",
+                "value": "0",
+                "gasLimit": "300000",
+            }
+        }
+        agent.session.get = MagicMock(return_value=resp)
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        w3.eth.gas_price = 10
+        w3.eth.get_transaction_count.return_value = 1
+        tx_hash = MagicMock()
+        tx_hash.hex.return_value = "0xHASH"
+        w3.eth.send_raw_transaction.return_value = tx_hash
+        cm.get_web3.return_value = w3
+        agent.wallet.sign_transaction.return_value = b"\xaa"
+        route = self._route("Li.Fi")
+        result = agent._execute_lifi(route)
+        assert result.tx_hash == "0xHASH"
+        assert result.bridge_name == "Li.Fi"
+
+    def test_execute_lifi_no_tx_data(self):
+        agent, *_ = _bridge()
+        resp = MagicMock()
+        resp.json.return_value = {}
+        agent.session.get = MagicMock(return_value=resp)
+        with pytest.raises(ValueError, match="No transaction data from Li.Fi"):
+            agent._execute_lifi(self._route("Li.Fi"))
+
+    def test_execute_socket(self):
+        agent, cm, _ = _bridge()
+        resp = MagicMock()
+        resp.json.return_value = {
+            "result": {
+                "txData": {
+                    "to": "0xTO",
+                    "data": "0xdata",
+                    "value": "0",
+                    "gasLimit": "300000",
+                }
+            }
+        }
+        agent.session.get = MagicMock(return_value=resp)
+        w3 = MagicMock()
+        w3.to_checksum_address.side_effect = lambda a: a
+        w3.eth.gas_price = 10
+        w3.eth.get_transaction_count.return_value = 1
+        tx_hash = MagicMock()
+        tx_hash.hex.return_value = "0xSOCK"
+        w3.eth.send_raw_transaction.return_value = tx_hash
+        cm.get_web3.return_value = w3
+        agent.wallet.sign_transaction.return_value = b"\xbb"
+        result = agent._execute_socket(self._route("hop"))
+        assert result.tx_hash == "0xSOCK"
+
+    def test_execute_socket_no_tx_data(self):
+        agent, *_ = _bridge()
+        resp = MagicMock()
+        resp.json.return_value = {"result": {}}
+        agent.session.get = MagicMock(return_value=resp)
+        with pytest.raises(ValueError, match="No transaction data from Socket"):
+            agent._execute_socket(self._route("hop"))
+
+    def test_repr(self):
+        agent, *_ = _bridge()
+        assert "BridgeAgent" in repr(agent)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_wallet_extra.py
+++ b/tests/test_wallet_extra.py
@@ -1,0 +1,182 @@
+"""Extra tests for Wallet — key/seed/keystore handling and tx signing."""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from eth_account import Account
+
+from web3_agent_kit.chains.chain import Chain
+from web3_agent_kit.wallet.wallet import Wallet, WalletConfig
+
+
+@pytest.fixture
+def test_key():
+    """A deterministic test private key."""
+    acct = Account.create()
+    return acct.key.hex(), acct.address
+
+
+class TestWalletConfig:
+    def test_defaults(self):
+        config = WalletConfig()
+        assert config.private_key is None
+        assert config.seed_phrase is None
+        assert config.keystore_path is None
+        assert config.password is None
+
+
+class TestWalletFromKey:
+    def test_from_key(self, test_key):
+        key, addr = test_key
+        wallet = Wallet.from_key(key)
+        assert wallet.address == addr
+        assert wallet.private_key == key
+
+    def test_from_env(self, test_key, monkeypatch):
+        key, addr = test_key
+        monkeypatch.setenv("MY_TEST_KEY", key)
+        wallet = Wallet.from_env("MY_TEST_KEY")
+        assert wallet.address == addr
+
+    def test_from_env_missing(self, monkeypatch):
+        monkeypatch.delenv("MISSING_KEY", raising=False)
+        with pytest.raises(ValueError, match="not set"):
+            Wallet.from_env("MISSING_KEY")
+
+    def test_get_account_no_key(self):
+        wallet = Wallet(WalletConfig())
+        with pytest.raises(ValueError, match="No private key"):
+            _ = wallet.address
+
+    def test_private_key_empty(self):
+        wallet = Wallet(WalletConfig())
+        assert wallet.private_key == ""
+
+    def test_repr(self, test_key):
+        key, _ = test_key
+        wallet = Wallet.from_key(key)
+        assert "Wallet(address=" in repr(wallet)
+
+
+class TestWalletFromSeed:
+    def test_from_seed(self):
+        Account.enable_unaudited_hdwallet_features()
+        acct, mnemonic = Account.create_with_mnemonic()
+        wallet = Wallet.from_seed(mnemonic)
+        assert wallet.address.startswith("0x")
+        assert len(wallet.address) == 42
+
+    def test_derive_account_no_seed(self):
+        wallet = Wallet(WalletConfig())
+        with pytest.raises(ValueError, match="No seed phrase"):
+            wallet._derive_account(0)
+
+
+class TestWalletFromKeystore:
+    def test_from_keystore_roundtrip(self, test_key):
+        key, addr = test_key
+        password = "hunter2"
+        keystore = Account.encrypt(key, password)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(keystore, f)
+            path = f.name
+        try:
+            wallet = Wallet.from_keystore(path, password)
+            assert wallet.address == addr
+            assert wallet.config.keystore_path == path
+        finally:
+            os.unlink(path)
+
+    def test_from_keystore_wrong_password(self, test_key):
+        key, _ = test_key
+        keystore = Account.encrypt(key, "correct")
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(keystore, f)
+            path = f.name
+        try:
+            with pytest.raises(ValueError):
+                Wallet.from_keystore(path, "wrong")
+        finally:
+            os.unlink(path)
+
+    def test_from_keystore_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            Wallet.from_keystore("/nonexistent/keystore.json", "pw")
+
+
+class TestWalletBalance:
+    def test_get_balance_no_chain_manager(self, test_key):
+        key, _ = test_key
+        wallet = Wallet.from_key(key)
+        with pytest.raises(ValueError, match="ChainManager not configured"):
+            wallet.get_balance(Chain.ETHEREUM)
+
+    def test_get_balance_evm(self, test_key):
+        key, _ = test_key
+        cm = MagicMock()
+        w3 = MagicMock()
+        w3.eth.get_balance.return_value = 2 * 10**18
+        w3.from_wei.return_value = 2.0
+        cm.get_web3.return_value = w3
+        wallet = Wallet.from_key(key, chain_manager=cm)
+        assert wallet.get_balance(Chain.ETHEREUM) == 2.0
+        cm.get_web3.assert_called_once_with(Chain.ETHEREUM)
+
+    def test_get_balance_solana(self, test_key):
+        key, _ = test_key
+        cm = MagicMock()
+        sol = MagicMock()
+        resp = MagicMock()
+        resp.value = 5_000_000_000
+        sol.get_balance.return_value = resp
+        cm.get_solana.return_value = sol
+        wallet = Wallet.from_key(key, chain_manager=cm)
+        assert wallet.get_balance(Chain.SOLANA) == 5.0
+
+
+class TestWalletTransactions:
+    def test_sign_transaction_no_key(self):
+        wallet = Wallet(WalletConfig())
+        with pytest.raises(ValueError, match="No private key"):
+            wallet.sign_transaction({}, Chain.ETHEREUM)
+
+    def test_sign_transaction(self, test_key):
+        key, _ = test_key
+        wallet = Wallet.from_key(key)
+        with patch.object(Account, "sign_transaction") as mock_sign:
+            signed = MagicMock()
+            signed.rawTransaction = b"\x01\x02"
+            mock_sign.return_value = signed
+            raw = wallet.sign_transaction({"nonce": 0}, Chain.ETHEREUM)
+            assert raw == b"\x01\x02"
+
+    def test_send_transaction_no_chain_manager(self, test_key):
+        key, _ = test_key
+        wallet = Wallet.from_key(key)
+        with pytest.raises(ValueError, match="ChainManager not configured"):
+            wallet.send_transaction({}, Chain.ETHEREUM)
+
+    def test_send_transaction(self, test_key):
+        key, _ = test_key
+        cm = MagicMock()
+        w3 = MagicMock()
+        tx_hash = MagicMock()
+        tx_hash.hex.return_value = "0xdeadbeef"
+        w3.eth.send_raw_transaction.return_value = tx_hash
+        cm.get_web3.return_value = w3
+        wallet = Wallet.from_key(key, chain_manager=cm)
+        with patch.object(wallet, "sign_transaction", return_value=b"\xaa"):
+            result = wallet.send_transaction({"nonce": 0}, Chain.ETHEREUM)
+        assert result == "0xdeadbeef"
+        w3.eth.send_raw_transaction.assert_called_once_with(b"\xaa")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_watcher_extra.py
+++ b/tests/test_watcher_extra.py
@@ -1,0 +1,256 @@
+"""Extra tests for WalletWatcher — monitoring, alerts, snapshots, persistence."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from web3_agent_kit.chains.chain import Chain
+from web3_agent_kit.wallet.watcher import (
+    AlertSeverity,
+    AlertType,
+    BalanceSnapshot,
+    WalletAlert,
+    WalletWatcher,
+    WatchedWallet,
+)
+
+
+@pytest.fixture
+def temp_storage():
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        path = f.name
+    os.unlink(path)  # start fresh
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+@pytest.fixture
+def watcher(temp_storage):
+    cm = MagicMock()
+    return WalletWatcher(cm, storage_path=temp_storage)
+
+
+def _mock_w3(balance_eth):
+    w3 = MagicMock()
+    w3.eth.get_balance.return_value = int(balance_eth * 10**18)
+    w3.from_wei.side_effect = lambda wei, _: wei / 10**18
+    return w3
+
+
+class TestAddRemoveList:
+    def test_add_wallet(self, watcher):
+        w = watcher.add_wallet("0xABC", "whale", Chain.ETHEREUM, tags=["dex"])
+        assert isinstance(w, WatchedWallet)
+        assert w.label == "whale"
+        assert "dex" in w.tags
+        assert len(watcher.wallets) == 1
+
+    def test_remove_wallet(self, watcher):
+        watcher.add_wallet("0xABC", "whale", Chain.ETHEREUM)
+        assert watcher.remove_wallet("0xABC", Chain.ETHEREUM) is True
+        assert len(watcher.wallets) == 0
+
+    def test_remove_nonexistent(self, watcher):
+        assert watcher.remove_wallet("0xDEAD", Chain.ETHEREUM) is False
+
+    def test_list_filters(self, watcher):
+        watcher.add_wallet("0x1", "a", Chain.ETHEREUM, tags=["hot"])
+        watcher.add_wallet("0x2", "b", Chain.BASE, tags=["cold"])
+        watcher.add_wallet("0x3", "c", Chain.ETHEREUM, tags=["hot"])
+        assert len(watcher.list_wallets()) == 3
+        assert len(watcher.list_wallets(chain=Chain.ETHEREUM)) == 2
+        assert len(watcher.list_wallets(tag="hot")) == 2
+
+    def test_list_active_only(self, watcher):
+        watcher.add_wallet("0x1", "a", Chain.ETHEREUM)
+        key = list(watcher.wallets)[0]
+        watcher.wallets[key].is_active = False
+        assert len(watcher.list_wallets(active_only=True)) == 0
+        assert len(watcher.list_wallets(active_only=False)) == 1
+
+
+class TestSnapshot:
+    def test_snapshot_success(self, watcher):
+        watcher.chain_manager.get_web3.return_value = _mock_w3(3.0)
+        with patch(
+            "web3_agent_kit.wallet.watcher.get_eth_price_usd", return_value=2000.0
+        ):
+            snap = watcher.snapshot("0xABC", Chain.ETHEREUM)
+        assert isinstance(snap, BalanceSnapshot)
+        assert snap.native_balance == 3.0
+        assert snap.total_value_usd == 6000.0
+        assert len(watcher.get_balance_history("0xABC")) == 1
+
+    def test_snapshot_error_returns_none(self, watcher):
+        watcher.chain_manager.get_web3.side_effect = RuntimeError("rpc down")
+        assert watcher.snapshot("0xABC", Chain.ETHEREUM) is None
+
+    def test_snapshot_all(self, watcher):
+        watcher.add_wallet("0x1", "a", Chain.ETHEREUM)
+        watcher.add_wallet("0x2", "b", Chain.ETHEREUM)
+        watcher.chain_manager.get_web3.return_value = _mock_w3(1.0)
+        with patch(
+            "web3_agent_kit.wallet.watcher.get_eth_price_usd", return_value=100.0
+        ):
+            snaps = watcher.snapshot_all()
+        assert len(snaps) == 2
+
+    def test_snapshot_history_capped(self, watcher):
+        watcher.chain_manager.get_web3.return_value = _mock_w3(1.0)
+        with patch(
+            "web3_agent_kit.wallet.watcher.get_eth_price_usd", return_value=1.0
+        ):
+            for _ in range(105):
+                watcher.snapshot("0xABC", Chain.ETHEREUM)
+        assert len(watcher.get_balance_history("0xABC")) == 100
+
+
+class TestCheckWallet:
+    def test_check_wallet_not_found(self, watcher):
+        assert watcher.check_wallet("0xNONE", Chain.ETHEREUM) == []
+
+    def test_check_wallet_first_snapshot_no_alert(self, watcher):
+        watcher.add_wallet("0xABC", "whale", Chain.ETHEREUM)
+        watcher.chain_manager.get_web3.return_value = _mock_w3(5.0)
+        with patch(
+            "web3_agent_kit.wallet.watcher.get_eth_price_usd", return_value=1.0
+        ):
+            alerts = watcher.check_wallet("0xABC", Chain.ETHEREUM)
+        assert alerts == []
+
+    def test_check_wallet_balance_change_alert(self, watcher):
+        watcher.add_wallet("0xABC", "whale", Chain.ETHEREUM)
+        # Seed a history snapshot at 5 ETH
+        watcher.snapshots["0xabc"] = [
+            BalanceSnapshot("0xABC", Chain.ETHEREUM, 5.0, {}, 5.0, 0)
+        ]
+        # Now the balance jumps to 20 ETH -> HIGH severity
+        watcher.chain_manager.get_web3.return_value = _mock_w3(20.0)
+        callback = MagicMock()
+        watcher.on_alert(callback)
+        with patch(
+            "web3_agent_kit.wallet.watcher.get_eth_price_usd", return_value=1.0
+        ):
+            alerts = watcher.check_wallet("0xABC", Chain.ETHEREUM)
+        assert len(alerts) == 1
+        assert alerts[0].alert_type == AlertType.BALANCE_CHANGE
+        assert alerts[0].severity == AlertSeverity.HIGH
+        callback.assert_called_once()
+
+    def test_check_wallet_callback_exception_swallowed(self, watcher):
+        watcher.add_wallet("0xABC", "whale", Chain.ETHEREUM)
+        watcher.snapshots["0xabc"] = [
+            BalanceSnapshot("0xABC", Chain.ETHEREUM, 1.0, {}, 1.0, 0)
+        ]
+        watcher.chain_manager.get_web3.return_value = _mock_w3(200.0)
+        watcher.on_alert(MagicMock(side_effect=RuntimeError("boom")))
+        with patch(
+            "web3_agent_kit.wallet.watcher.get_eth_price_usd", return_value=1.0
+        ):
+            alerts = watcher.check_wallet("0xABC", Chain.ETHEREUM)
+        assert alerts[0].severity == AlertSeverity.CRITICAL
+
+    def test_check_all(self, watcher):
+        watcher.add_wallet("0x1", "a", Chain.ETHEREUM)
+        watcher.snapshots["0x1"] = [
+            BalanceSnapshot("0x1", Chain.ETHEREUM, 1.0, {}, 1.0, 0)
+        ]
+        watcher.chain_manager.get_web3.return_value = _mock_w3(3.0)
+        with patch(
+            "web3_agent_kit.wallet.watcher.get_eth_price_usd", return_value=1.0
+        ):
+            alerts = watcher.check_all()
+        assert len(alerts) == 1
+        assert alerts[0].severity == AlertSeverity.MEDIUM
+
+
+class TestAlerts:
+    def _mk_watcher(self, temp_storage):
+        return WalletWatcher(MagicMock(), storage_path=temp_storage)
+
+    def test_get_alerts_filters(self, watcher):
+        a1 = WalletAlert(
+            "0x1", "a", Chain.ETHEREUM, AlertType.BALANCE_CHANGE,
+            AlertSeverity.LOW, "m1",
+        )
+        a2 = WalletAlert(
+            "0x2", "b", Chain.ETHEREUM, AlertType.LARGE_TRANSFER,
+            AlertSeverity.HIGH, "m2",
+        )
+        watcher.alerts = [a1, a2]
+        assert len(watcher.get_alerts()) == 2
+        assert len(watcher.get_alerts(severity=AlertSeverity.HIGH)) == 1
+        assert len(watcher.get_alerts(wallet_label="a")) == 1
+
+    def test_acknowledge_alert(self, watcher):
+        watcher.alerts = [
+            WalletAlert(
+                "0x1", "a", Chain.ETHEREUM, AlertType.BALANCE_CHANGE,
+                AlertSeverity.LOW, "m1",
+            )
+        ]
+        assert watcher.acknowledge_alert(0) is True
+        assert watcher.alerts[0].acknowledged is True
+        assert watcher.acknowledge_alert(99) is False
+        # acknowledged excluded by default
+        assert len(watcher.get_alerts()) == 0
+
+    def test_acknowledge_all(self, watcher):
+        watcher.alerts = [
+            WalletAlert(
+                "0x1", "a", Chain.ETHEREUM, AlertType.BALANCE_CHANGE,
+                AlertSeverity.LOW, str(i),
+            )
+            for i in range(3)
+        ]
+        assert watcher.acknowledge_all() == 3
+        assert watcher.acknowledge_all() == 0
+
+
+class TestSummaryAndPersistence:
+    def test_get_summary(self, watcher):
+        watcher.add_wallet("0x1234567890abcdef", "a", Chain.ETHEREUM, tags=["x"])
+        watcher.alerts = [
+            WalletAlert(
+                "0x1", "a", Chain.ETHEREUM, AlertType.BALANCE_CHANGE,
+                AlertSeverity.LOW, "m",
+            )
+        ]
+        summary = watcher.get_summary()
+        assert summary["watched_wallets"] == 1
+        assert summary["total_alerts"] == 1
+        assert summary["unacknowledged_alerts"] == 1
+        assert "ethereum" in summary["chains"]
+        assert summary["wallets"][0]["label"] == "a"
+
+    def test_save_and_load_wallets(self, temp_storage):
+        cm = MagicMock()
+        w1 = WalletWatcher(cm, storage_path=temp_storage)
+        w1.add_wallet("0xABC", "whale", Chain.BASE, tags=["t"],
+                      alert_threshold_usd=5000)
+        # New watcher loads the persisted file
+        w2 = WalletWatcher(cm, storage_path=temp_storage)
+        assert len(w2.wallets) == 1
+        loaded = list(w2.wallets.values())[0]
+        assert loaded.label == "whale"
+        assert loaded.chain == Chain.BASE
+        assert loaded.alert_threshold_usd == 5000
+
+    def test_load_wallets_corrupt_file(self, temp_storage):
+        with open(temp_storage, "w") as f:
+            f.write("not valid json {{{")
+        cm = MagicMock()
+        w = WalletWatcher(cm, storage_path=temp_storage)
+        assert len(w.wallets) == 0
+
+    def test_load_missing_file_noop(self, temp_storage):
+        cm = MagicMock()
+        w = WalletWatcher(cm, storage_path=temp_storage)
+        assert w.wallets == {}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- **+466 new offline tests** (all network/RPC/LLM mocked) across 11 new test files: API server routes & models, CLI commands, airdrop executor CLI, messaging, events, governance, account abstraction, portfolio tracker, agent core, wallet, watcher, sniper, bridge, airdrop scheduler & dashboard
- **Coverage: 60.04% -> 73.77%** (whole package)
- Coverage gate (`fail_under`) raised 60 -> 70 so it can't regress
- README badge updated to 73%

## Test Plan
- `pytest` -> **1670 passed, 11 skipped** in ~41s
- `ruff check .` -> all checks passed
- `Required test coverage of 70.0% reached. Total coverage: 73.77%`