### PR TITLE
fix: wire API wallet/portfolio routes to use PRIVATE_KEY and ChainManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- REST wallet, portfolio, swap, and bridge routes now read `PRIVATE_KEY` instead of
+  mistakenly treating the requested chain name as an environment variable. Balance
+  routes also configure a chain manager and pass the selected chain to wallet lookups.
+- The `dev` extra now includes Hypothesis, which is required to collect the fuzz tests.
+
+### Added
+
+- Added an `api` installation extra for the FastAPI and Uvicorn server dependencies.
+
 ## [1.15.0] - 2026-07-23
 
 ### BREAKING CHANGE

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -13,6 +13,9 @@ non-Python client.
 ## Quick Start
 
 ```bash
+# Install the optional API dependencies when using the PyPI package
+pip install "web3-agent-kit[api]"
+
 # 1. Generate a strong API key
 python -c "import secrets; print(secrets.token_hex(32))"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.23.0",
+    "hypothesis>=6.0",
     "ruff>=0.1.0",
 ]
 solana = [
@@ -49,6 +50,10 @@ solana = [
     "solana>=0.35.0",
     "base58>=2.1.0",
     "httpx>=0.25.0",
+]
+api = [
+    "fastapi>=0.140.7",
+    "uvicorn>=0.27.0",
 ]
 
 [project.urls]

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -45,7 +45,9 @@ pytestmark = pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not insta
 
 class TestWalletRoutes:
     def test_info_happy(self):
-        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet, patch(
+            "web3_agent_kit.chains.chain.ChainManager"
+        ) as MockManager:
             inst = MagicMock()
             inst.address = "0xabc"
             inst.get_balance.return_value = 2.0
@@ -56,6 +58,10 @@ class TestWalletRoutes:
             assert data["address"] == "0xabc"
             assert data["chain"] == "ethereum"
             assert data["balance"] == "2.0"
+            MockWallet.from_env.assert_called_once_with(
+                "PRIVATE_KEY", chain_manager=MockManager.return_value
+            )
+            assert inst.get_balance.call_args.args[0].value == "ethereum"
 
     def test_info_error_path(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -63,6 +69,11 @@ class TestWalletRoutes:
             resp = client.get("/wallet/info", headers=AUTH_HEADERS)
             assert resp.status_code == 400
             assert "no wallet" in resp.json()["detail"]
+
+    def test_info_rejects_unsupported_chain(self):
+        resp = client.get("/wallet/info?chain=bogus", headers=AUTH_HEADERS)
+        assert resp.status_code == 400
+        assert "bogus" in resp.json()["detail"]
 
     def test_create_disabled_by_default(self, monkeypatch):
         monkeypatch.delenv("ENABLE_WALLET_CREATE_ENDPOINT", raising=False)
@@ -168,6 +179,7 @@ class TestSwapRoutes:
             )
             assert resp.status_code == 200
             assert resp.json()["status"] == "success"
+            MockWallet.from_env.assert_called_once_with("PRIVATE_KEY")
 
     def test_execute_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -200,7 +212,9 @@ class TestSwapRoutes:
 
 class TestPortfolioRoutes:
     def test_portfolio_happy(self):
-        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet, patch(
+            "web3_agent_kit.chains.chain.ChainManager"
+        ) as MockManager:
             inst = MagicMock()
             inst.address = "0xabc"
             inst.get_balance.return_value = 1.0
@@ -210,6 +224,10 @@ class TestPortfolioRoutes:
             data = resp.json()
             assert data["address"] == "0xabc"
             assert data["native_balance"] == "1.0"
+            MockWallet.from_env.assert_called_once_with(
+                "PRIVATE_KEY", chain_manager=MockManager.return_value
+            )
+            assert inst.get_balance.call_args.args[0].value == "ethereum"
 
     def test_portfolio_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -217,8 +235,15 @@ class TestPortfolioRoutes:
             resp = client.get("/portfolio/", headers=AUTH_HEADERS)
             assert resp.status_code == 400
 
+    def test_portfolio_rejects_unsupported_chain(self):
+        resp = client.get("/portfolio/?chain=bogus", headers=AUTH_HEADERS)
+        assert resp.status_code == 400
+        assert "bogus" in resp.json()["detail"]
+
     def test_portfolio_value_happy(self):
-        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet, patch(
+            "web3_agent_kit.chains.chain.ChainManager"
+        ) as MockManager:
             inst = MagicMock()
             inst.address = "0xabc"
             inst.get_balance.return_value = 4.2
@@ -226,6 +251,10 @@ class TestPortfolioRoutes:
             resp = client.get("/portfolio/value", headers=AUTH_HEADERS)
             assert resp.status_code == 200
             assert resp.json()["native_balance"] == "4.2"
+            MockWallet.from_env.assert_called_once_with(
+                "PRIVATE_KEY", chain_manager=MockManager.return_value
+            )
+            assert inst.get_balance.call_args.args[0].value == "ethereum"
 
     def test_portfolio_value_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -705,6 +734,7 @@ class TestBridgeRoutes:
             resp = client.post("/bridge/execute", headers=AUTH_HEADERS)
             assert resp.status_code == 200
             assert resp.json()["tx_hash"] == "0xbridge"
+            MockWallet.from_env.assert_called_once_with("PRIVATE_KEY")
 
     def test_execute_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:

--- a/web3_agent_kit/api/routes/bridge.py
+++ b/web3_agent_kit/api/routes/bridge.py
@@ -37,7 +37,7 @@ async def execute_bridge(
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(from_chain)
+        wallet = Wallet.from_env("PRIVATE_KEY")
         agent = BridgeAgent(from_chain)
         result = agent.transfer(wallet, to_chain, token, amount)
         return result

--- a/web3_agent_kit/api/routes/portfolio.py
+++ b/web3_agent_kit/api/routes/portfolio.py
@@ -10,11 +10,14 @@ router = APIRouter()
 @router.get("/")
 async def get_portfolio(chain: str = "ethereum"):
     """Get full portfolio with token balances and USD values."""
+    from ...chains.chain import Chain, ChainManager
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
-        balance = wallet.get_balance()
+        chain_enum = Chain(chain)
+        manager = ChainManager([chain_enum])
+        wallet = Wallet.from_env("PRIVATE_KEY", chain_manager=manager)
+        balance = wallet.get_balance(chain_enum)
         return {
             "address": wallet.address,
             "chain": chain,
@@ -28,11 +31,14 @@ async def get_portfolio(chain: str = "ethereum"):
 @router.get("/value")
 async def get_portfolio_value(chain: str = "ethereum"):
     """Get total portfolio value in USD."""
+    from ...chains.chain import Chain, ChainManager
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
-        balance = wallet.get_balance()
+        chain_enum = Chain(chain)
+        manager = ChainManager([chain_enum])
+        wallet = Wallet.from_env("PRIVATE_KEY", chain_manager=manager)
+        balance = wallet.get_balance(chain_enum)
         return {
             "address": wallet.address,
             "chain": chain,

--- a/web3_agent_kit/api/routes/swap.py
+++ b/web3_agent_kit/api/routes/swap.py
@@ -39,7 +39,7 @@ async def execute_swap(
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
+        wallet = Wallet.from_env("PRIVATE_KEY")
         uni = Uniswap(chain)
         result = uni.execute(wallet, token_in, token_out, amount_in, slippage)
         return result

--- a/web3_agent_kit/api/routes/wallet.py
+++ b/web3_agent_kit/api/routes/wallet.py
@@ -12,11 +12,14 @@ router = APIRouter()
 @router.get("/info")
 async def get_wallet_info(chain: str = "ethereum"):
     """Get current wallet info and balance."""
+    from ...chains.chain import Chain, ChainManager
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
-        balance = wallet.get_balance()
+        chain_enum = Chain(chain)
+        manager = ChainManager([chain_enum])
+        wallet = Wallet.from_env("PRIVATE_KEY", chain_manager=manager)
+        balance = wallet.get_balance(chain_enum)
         return {
             "address": wallet.address,
             "chain": chain,


### PR DESCRIPTION
### Motivation

- Fix REST API bug where the requested chain name was mistakenly treated as an environment variable containing the private key, causing incorrect wallet lookups and balances.
- Ensure API route handlers consistently load the configured wallet and respect the selected chain when querying balances.

### Description

- Update `GET /wallet/info` and portfolio routes to construct a `ChainManager`, convert the `chain` string to `Chain`, load the wallet from `PRIVATE_KEY` via `Wallet.from_env(..., chain_manager=...)`, and pass the selected `Chain` to `get_balance()`.
- Make swap and bridge execution endpoints consistently load the wallet from `PRIVATE_KEY` instead of using the chain name as an env var.
- Add `hypothesis>=6.0` to the `dev` optional dependencies and introduce an `api` extra with `fastapi` and `uvicorn`; document installing the API extra in `docs/api-server.md`.
- Extend and adjust API tests in `tests/test_api_routes.py` to mock `ChainManager`, assert the new wiring, and add tests rejecting unsupported chains; update `CHANGELOG.md` to record the fix.

### Testing

- Ran `python -m ruff check .` which passed without errors.
- Ran the targeted API tests with `python -m pytest tests/test_api_routes.py -q -o addopts=''`, which passed (89 passed, 1 warning).
- Ran `python -m compileall -q web3_agent_kit tests` and `git diff --check` which completed cleanly.
- Attempted to run the full test suite and to install `hypothesis`/`pytest-cov`, but package-index access failed (HTTP 403) so the full coverage-enabled suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2940bca88331ab473317720a70b7)