### PR TITLE
Surface module maturity (beta), fix API wallet/chain handling, add docs and extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- Added a formal module-maturity policy, surfaced the beta status and safe-use
-  guidance in the README and CLI, and synchronized the supported-version policy.
-
-### Fixed
-
-- REST wallet, portfolio, swap, and bridge routes now read `PRIVATE_KEY` instead of
-  mistakenly treating the requested chain name as an environment variable. Balance
-  routes also configure a chain manager and pass the selected chain to wallet lookups.
-- The `dev` extra now includes Hypothesis, which is required to collect the fuzz tests.
-
-### Added
-
-- Added an `api` installation extra for the FastAPI and Uvicorn server dependencies.
-
 ## [1.15.0] - 2026-07-23
 
 ### BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Added a formal module-maturity policy, surfaced the beta status and safe-use
+  guidance in the README and CLI, and synchronized the supported-version policy.
+
+### Fixed
+
+- REST wallet, portfolio, swap, and bridge routes now read `PRIVATE_KEY` instead of
+  mistakenly treating the requested chain name as an environment variable. Balance
+  routes also configure a chain manager and pass the selected chain to wallet lookups.
+- The `dev` extra now includes Hypothesis, which is required to collect the fuzz tests.
+
+### Added
+
+- Added an `api` installation extra for the FastAPI and Uvicorn server dependencies.
+
 ## [1.15.0] - 2026-07-23
 
 ### BREAKING CHANGE

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 > **Build autonomous AI agents that interact with blockchains — in minutes, not months.**
 
+> [!WARNING]
+> Web3 Agent Kit is beta software. Module readiness ranges from stable to
+> experimental, and availability does not imply unattended mainnet safety.
+> Review the [maturity policy](docs/project-maturity.md) and [risk disclosure](RISKS.md)
+> before using real funds.
+
 [![PyPI](https://img.shields.io/pypi/v/web3-agent-kit.svg)](https://pypi.org/project/web3-agent-kit/)
 [![Downloads](https://img.shields.io/pypi/dm/web3-agent-kit.svg)](https://pypi.org/project/web3-agent-kit/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Current version:** v1.15.0  
 > **Updated:** 2026-07-23  
 > **Modules:** 25  
-> **Tests:** 1,248+ (62% coverage)  
+> **Tests:** 1,248+ (70% coverage gate)
 > **Chains:** 8 (Ethereum, Base, Polygon, Arbitrum, Optimism, BSC, Avalanche, Solana)
 
 ---
@@ -41,7 +41,7 @@
 | SpendGovernor + confirm_fn wiring | ✅ |
 | Honeypot fail-open fix (3-state) | ✅ |
 | `swap_exact_output` protections | ✅ |
-| Coverage gate 60% | ✅ |
+| Coverage gate 70% | ✅ |
 | Dependabot + pip-audit CI | ✅ |
 | Release-please draft workflow | ✅ |
 | MCP server scaffold | ✅ |
@@ -59,37 +59,39 @@
 | **Supply-chain security** | ✅ | Scorecard, SBOM, lockfile, pinned actions |
 | **Governance documentation** | ✅ | DCO, versioning-policy, SECURITY.md, fuzz tests |
 
-## Phase 5 — Supply-Chain Security (planned)
+## Phase 5 — Stabilization & Trust (current)
 
-| Feature | Priority | Notes |
-|---------|----------|-------|
-| PyPI Trusted Publishing (OIDC) | High | Replace static API token |
-| Pin GH Actions to commit SHA | High | Supply-chain attack protection |
-| SBOM generation per release | Medium | `cyclonedx-py` |
-| Sigstore/cosign signing | Medium | Keyless via OIDC |
-| Hash-pinned lockfile | Medium | `pip-compile --generate-hashes` |
-| OpenSSF Scorecard | Medium | Public trust badge |
-| 2FA for PyPI + GitHub org | Low | Manual setup required |
+New integrations are lower priority until the execution path is safe,
+observable, and consistently tested.
 
-## Phase 6 — Governance (planned)
+| Outcome | Priority | Exit criterion |
+|---------|----------|----------------|
+| Module maturity policy | High | Every capability is classified as stable, beta, or experimental |
+| Unified transaction policy | High | Every write path uses limits, allowlists, and explicit confirmation rules |
+| Pre-flight simulation | High | Every supported write path can be simulated before signing |
+| Signer abstraction | High | Core execution does not require direct access to a raw private key |
+| Typed public API | Medium | Public interfaces pass static type checking in CI |
+| Test isolation | Medium | Unit, integration, network, and security suites are independently runnable |
+| Documentation consistency | Medium | Version, support, coverage, and readiness claims have one source of truth |
+| External security review | Medium | Critical execution paths reviewed before a v2.0 stable release |
 
-| Feature | Priority | Notes |
-|---------|----------|-------|
-| `GOVERNANCE.md` | High | Maintainer roles, decision process, bus factor |
-| `CODEOWNERS` | High | Mandatory review for wallet/security/agent paths |
-| DCO (Signed-off-by) check | Medium | Lighter than CLA |
-| `SECURITY.md` upgrade | Medium | GHSA workflow, safe-harbor statement |
-| `RISKS.md` | Medium | Specific disclaimer for fund-loss risk |
-| `versioning-policy.md` | Medium | SemVer commitment, deprecation process |
-| Fuzz testing (`hypothesis`) | Low | Slippage, gas, approval edge cases |
-| External security audit | Low | Post-2.0, fundable via ecosystem grants |
+## Phase 6 — Production Proof (planned)
+
+| Outcome | Priority | Exit criterion |
+|---------|----------|----------------|
+| Safe portfolio reference agent | High | Read-only by default, simulated writes, human approval |
+| Policy-controlled DCA agent | High | Allowlisted assets, bounded value/slippage, complete audit trail |
+| Testnet soak testing | High | Continuous multi-day runs without unresolved critical failures |
+| Design partners | Medium | At least three external projects validate real workflows |
+| Maintainer ownership | Medium | Named owners and support expectations for stable modules |
+| v2.0 release candidate | Medium | Migration guide, compatibility policy, and security review complete |
 
 ## Beyond
 
 | Idea | Status |
 |------|--------|
 | Hardware wallet support | Exploring |
-| Transaction simulation in Agent | Exploring |
+| Transaction simulation in Agent | Phase 5 priority |
 | Webhook notifications | Exploring |
 | Zeroisation of private keys | Researching |
 | On-chain incident monitoring | Researching |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,11 @@
 
 | Version | Supported |
 |---------|-----------|
-| 1.6.x | ✅ |
-| 1.5.x | ✅ |
-| < 1.5 | ❌ |
+| 1.15.x | ✅ |
+| < 1.15 | ❌ |
+
+Security fixes are released for the latest minor series. Users should upgrade
+before reporting an issue that has already been fixed in a newer release.
 
 ## Safe Harbor
 

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -13,6 +13,9 @@ non-Python client.
 ## Quick Start
 
 ```bash
+# Install the optional API dependencies when using the PyPI package
+pip install "web3-agent-kit[api]"
+
 # 1. Generate a strong API key
 python -c "import secrets; print(secrets.token_hex(32))"
 

--- a/docs/project-maturity.md
+++ b/docs/project-maturity.md
@@ -1,0 +1,66 @@
+# Project Maturity
+
+Web3 Agent Kit is currently **beta software**. Its modules do not all have the
+same production-readiness level. A feature being available does not mean it has
+been validated for unattended use with real funds.
+
+## Maturity levels
+
+| Level | Stability promise | Intended use |
+|---|---|---|
+| **Stable** | Backward-compatible within a major version, with offline tests and documented failure modes | Production use with appropriate operational controls |
+| **Beta** | Functional and tested, but APIs or behavior may change between minor versions | Controlled pilots and testnet-first deployments |
+| **Experimental** | Best-effort implementation with limited compatibility guarantees | Research, evaluation, and testnets only |
+
+No maturity level eliminates blockchain, smart-contract, key-management, or
+market risk. Always review the [risk disclosure](https://github.com/ulsreall/web3-agent-kit/blob/master/RISKS.md) and
+[security model](security-model.md).
+
+## Current classification
+
+| Area | Level | Notes |
+|---|---|---|
+| Chain configuration and read-only RPC access | Stable | Validate provider availability and chain identity in deployments |
+| Wallet primitives and transaction signing | Beta | Local keys remain sensitive in process memory |
+| Spend governor and approval analysis | Beta | Configure explicit limits and confirmation callbacks |
+| Agent planning and LLM integrations | Beta | LLM output must be treated as untrusted input |
+| REST API and CLI | Beta | The API must remain authenticated and should be exposed only over a trusted network |
+| DeFi, bridge, trading, and yield execution | Experimental | Protocol behavior and external APIs can change without notice |
+| Solana, NFT, MEV, airdrop, governance, messaging, and account abstraction | Experimental | Testnet and evaluation use only |
+
+The classification is intentionally conservative. A module moves to a higher
+level only after satisfying the release criteria below.
+
+## Promotion criteria
+
+### Experimental to Beta
+
+- Public interfaces and supported networks are documented.
+- Inputs, addresses, amounts, slippage, and deadlines are validated.
+- Unit tests do not require live network access.
+- Integration behavior and failure paths are covered with deterministic tests.
+- A runnable testnet or dry-run example exists.
+- Known financial and operational risks are documented.
+
+### Beta to Stable
+
+- The public API has a documented compatibility commitment.
+- Transaction-building and signing boundaries have been security reviewed.
+- Write operations support policy enforcement and pre-flight simulation.
+- Operational telemetry is available without exposing secrets.
+- At least one release cycle has completed without unresolved critical defects.
+- A named maintainer owns the module.
+
+## Safe adoption path
+
+1. Start with read-only calls.
+2. Use a testnet or local fork.
+3. Configure the spend governor and a human confirmation callback.
+4. Restrict allowed chains, contracts, tokens, and transaction values.
+5. Simulate every write operation before signing.
+6. Use a dedicated wallet containing only the minimum required funds.
+7. Monitor transactions and keep an emergency shutdown procedure.
+
+Production readiness is a property of the complete deployment—not only the
+library. RPC providers, signers, policies, monitoring, network exposure, and
+upstream protocols must all be assessed together.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
   - CLI Tool: cli.md
   - REST API Server: api-server.md
   - Features: features.md
+  - Project Maturity: project-maturity.md
   - Examples: examples.md
   - API Reference:
     - api/agent.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.23.0",
+    "hypothesis>=6.0",
     "ruff>=0.1.0",
 ]
 solana = [
@@ -49,6 +50,10 @@ solana = [
     "solana>=0.35.0",
     "base58>=2.1.0",
     "httpx>=0.25.0",
+]
+api = [
+    "fastapi>=0.140.7",
+    "uvicorn>=0.27.0",
 ]
 
 [project.urls]

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -45,7 +45,9 @@ pytestmark = pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not insta
 
 class TestWalletRoutes:
     def test_info_happy(self):
-        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet, patch(
+            "web3_agent_kit.chains.chain.ChainManager"
+        ) as MockManager:
             inst = MagicMock()
             inst.address = "0xabc"
             inst.get_balance.return_value = 2.0
@@ -56,6 +58,10 @@ class TestWalletRoutes:
             assert data["address"] == "0xabc"
             assert data["chain"] == "ethereum"
             assert data["balance"] == "2.0"
+            MockWallet.from_env.assert_called_once_with(
+                "PRIVATE_KEY", chain_manager=MockManager.return_value
+            )
+            assert inst.get_balance.call_args.args[0].value == "ethereum"
 
     def test_info_error_path(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -63,6 +69,11 @@ class TestWalletRoutes:
             resp = client.get("/wallet/info", headers=AUTH_HEADERS)
             assert resp.status_code == 400
             assert "no wallet" in resp.json()["detail"]
+
+    def test_info_rejects_unsupported_chain(self):
+        resp = client.get("/wallet/info?chain=bogus", headers=AUTH_HEADERS)
+        assert resp.status_code == 400
+        assert "bogus" in resp.json()["detail"]
 
     def test_create_disabled_by_default(self, monkeypatch):
         monkeypatch.delenv("ENABLE_WALLET_CREATE_ENDPOINT", raising=False)
@@ -168,6 +179,7 @@ class TestSwapRoutes:
             )
             assert resp.status_code == 200
             assert resp.json()["status"] == "success"
+            MockWallet.from_env.assert_called_once_with("PRIVATE_KEY")
 
     def test_execute_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -200,7 +212,9 @@ class TestSwapRoutes:
 
 class TestPortfolioRoutes:
     def test_portfolio_happy(self):
-        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet, patch(
+            "web3_agent_kit.chains.chain.ChainManager"
+        ) as MockManager:
             inst = MagicMock()
             inst.address = "0xabc"
             inst.get_balance.return_value = 1.0
@@ -210,6 +224,10 @@ class TestPortfolioRoutes:
             data = resp.json()
             assert data["address"] == "0xabc"
             assert data["native_balance"] == "1.0"
+            MockWallet.from_env.assert_called_once_with(
+                "PRIVATE_KEY", chain_manager=MockManager.return_value
+            )
+            assert inst.get_balance.call_args.args[0].value == "ethereum"
 
     def test_portfolio_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -217,8 +235,15 @@ class TestPortfolioRoutes:
             resp = client.get("/portfolio/", headers=AUTH_HEADERS)
             assert resp.status_code == 400
 
+    def test_portfolio_rejects_unsupported_chain(self):
+        resp = client.get("/portfolio/?chain=bogus", headers=AUTH_HEADERS)
+        assert resp.status_code == 400
+        assert "bogus" in resp.json()["detail"]
+
     def test_portfolio_value_happy(self):
-        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
+        with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet, patch(
+            "web3_agent_kit.chains.chain.ChainManager"
+        ) as MockManager:
             inst = MagicMock()
             inst.address = "0xabc"
             inst.get_balance.return_value = 4.2
@@ -226,6 +251,10 @@ class TestPortfolioRoutes:
             resp = client.get("/portfolio/value", headers=AUTH_HEADERS)
             assert resp.status_code == 200
             assert resp.json()["native_balance"] == "4.2"
+            MockWallet.from_env.assert_called_once_with(
+                "PRIVATE_KEY", chain_manager=MockManager.return_value
+            )
+            assert inst.get_balance.call_args.args[0].value == "ethereum"
 
     def test_portfolio_value_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:
@@ -705,6 +734,7 @@ class TestBridgeRoutes:
             resp = client.post("/bridge/execute", headers=AUTH_HEADERS)
             assert resp.status_code == 200
             assert resp.json()["tx_hash"] == "0xbridge"
+            MockWallet.from_env.assert_called_once_with("PRIVATE_KEY")
 
     def test_execute_error(self):
         with patch("web3_agent_kit.wallet.wallet.Wallet") as MockWallet:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,8 @@ class TestInfoCommand:
         result = runner.invoke(info, [])
         assert result.exit_code == 0
         assert "web3-agent-kit" in result.output
+        assert "Beta (module maturity varies)" in result.output
+        assert "Use testnets and explicit spending limits" in result.output
         assert "Capabilities" in result.output
         assert "Links" in result.output
 

--- a/web3_agent_kit/api/routes/bridge.py
+++ b/web3_agent_kit/api/routes/bridge.py
@@ -37,7 +37,7 @@ async def execute_bridge(
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(from_chain)
+        wallet = Wallet.from_env("PRIVATE_KEY")
         agent = BridgeAgent(from_chain)
         result = agent.transfer(wallet, to_chain, token, amount)
         return result

--- a/web3_agent_kit/api/routes/portfolio.py
+++ b/web3_agent_kit/api/routes/portfolio.py
@@ -10,11 +10,14 @@ router = APIRouter()
 @router.get("/")
 async def get_portfolio(chain: str = "ethereum"):
     """Get full portfolio with token balances and USD values."""
+    from ...chains.chain import Chain, ChainManager
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
-        balance = wallet.get_balance()
+        chain_enum = Chain(chain)
+        manager = ChainManager([chain_enum])
+        wallet = Wallet.from_env("PRIVATE_KEY", chain_manager=manager)
+        balance = wallet.get_balance(chain_enum)
         return {
             "address": wallet.address,
             "chain": chain,
@@ -28,11 +31,14 @@ async def get_portfolio(chain: str = "ethereum"):
 @router.get("/value")
 async def get_portfolio_value(chain: str = "ethereum"):
     """Get total portfolio value in USD."""
+    from ...chains.chain import Chain, ChainManager
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
-        balance = wallet.get_balance()
+        chain_enum = Chain(chain)
+        manager = ChainManager([chain_enum])
+        wallet = Wallet.from_env("PRIVATE_KEY", chain_manager=manager)
+        balance = wallet.get_balance(chain_enum)
         return {
             "address": wallet.address,
             "chain": chain,

--- a/web3_agent_kit/api/routes/swap.py
+++ b/web3_agent_kit/api/routes/swap.py
@@ -39,7 +39,7 @@ async def execute_swap(
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
+        wallet = Wallet.from_env("PRIVATE_KEY")
         uni = Uniswap(chain)
         result = uni.execute(wallet, token_in, token_out, amount_in, slippage)
         return result

--- a/web3_agent_kit/api/routes/wallet.py
+++ b/web3_agent_kit/api/routes/wallet.py
@@ -12,11 +12,14 @@ router = APIRouter()
 @router.get("/info")
 async def get_wallet_info(chain: str = "ethereum"):
     """Get current wallet info and balance."""
+    from ...chains.chain import Chain, ChainManager
     from ...wallet.wallet import Wallet
 
     try:
-        wallet = Wallet.from_env(chain)
-        balance = wallet.get_balance()
+        chain_enum = Chain(chain)
+        manager = ChainManager([chain_enum])
+        wallet = Wallet.from_env("PRIVATE_KEY", chain_manager=manager)
+        balance = wallet.get_balance(chain_enum)
         return {
             "address": wallet.address,
             "chain": chain,

--- a/web3_agent_kit/cli/commands/info.py
+++ b/web3_agent_kit/cli/commands/info.py
@@ -73,6 +73,14 @@ def info():
     click.echo(click.style("  Chains:   ", fg="yellow") + f"{chain_count} networks (EVM + Solana)")
     click.echo(click.style("  Python:   ", fg="yellow") + ">=3.10")
     click.echo(click.style("  License:  ", fg="yellow") + "MIT")
+    click.echo(click.style("  Status:   ", fg="yellow") + "Beta (module maturity varies)")
+    click.echo()
+
+    click.echo(
+        click.style("  ⚠ Safety: ", fg="yellow", bold=True)
+        + "Use testnets and explicit spending limits before risking real funds."
+    )
+    click.echo("    Maturity → https://ulsreall.github.io/web3-agent-kit/project-maturity/")
     click.echo()
 
     # Capabilities


### PR DESCRIPTION
### Motivation

- Make the library's module maturity and safety posture explicit by surfacing beta warnings in the README and CLI and by adding a formal maturity policy document.
- Fix incorrect REST API behavior where route handlers treated the requested chain name as an environment variable instead of using the configured private key and chain manager.
- Provide installation ergonomics for the optional REST API server and enable fuzz testing in the `dev` extras.

### Description

- Added a new `docs/project-maturity.md` and inserted a beta safety warning into `README.md`, plus updated `mkdocs.yml` navigation and `ROADMAP.md`/`CHANGELOG.md`/`SECURITY.md` entries to reflect the maturity policy and test/coverage goals.
- Updated CLI `info` output in `web3_agent_kit/cli/commands/info.py` to show `Beta (module maturity varies)` and a safety hint linking to the maturity page.
- Introduced an `api` optional dependency extra and added `hypothesis` to the `dev` extra in `pyproject.toml`. 
- Fixed API route handlers to use `Wallet.from_env("PRIVATE_KEY")`, create a `ChainManager` and pass `Chain` enums to wallet lookups in `web3_agent_kit/api/routes/{wallet,portfolio,swap,bridge}.py` to avoid treating chain names as env vars. 
- Updated tests in `tests/test_api_routes.py` to mock `ChainManager`, assert `Wallet.from_env("PRIVATE_KEY")` calls, and add unsupported-chain rejection tests, and adjusted `tests/test_cli.py` expectations for the CLI status message.

### Testing

- Ran the test suite with `pytest` after updates, exercising the API route tests and CLI tests, and all tests passed.
- API route unit tests were updated to assert `Wallet.from_env` usage and chain-manager wiring and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2940bca88331ab473317720a70b7)