### PR TITLE
Add execution primitives: TransactionIntent, errors, and tests

### DIFF
--- a/tests/test_execution_intent.py
+++ b/tests/test_execution_intent.py
@@ -1,0 +1,271 @@
+"""Offline tests for immutable transaction intents."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from web3_agent_kit.chains import Chain
+from web3_agent_kit.execution import (
+    ActionType,
+    InvalidAddressError,
+    InvalidAmountError,
+    InvalidCalldataError,
+    InvalidIntentError,
+    InvalidMetadataError,
+    TransactionIntent,
+    UnsupportedActionError,
+    UnsupportedChainError,
+)
+
+SENDER = "0x1111111111111111111111111111111111111111"
+RECIPIENT = "0x2222222222222222222222222222222222222222"
+CONTRACT = "0x3333333333333333333333333333333333333333"
+TOKEN = "0x4444444444444444444444444444444444444444"
+
+
+def native_intent(**overrides) -> TransactionIntent:
+    values = {
+        "chain": Chain.BASE,
+        "action": ActionType.TRANSFER_NATIVE,
+        "sender": SENDER,
+        "recipient": RECIPIENT,
+        "native_value_wei": 10**18,
+    }
+    values.update(overrides)
+    return TransactionIntent(**values)
+
+
+class TestValidIntents:
+    def test_native_transfer(self):
+        intent = native_intent()
+        assert intent.chain == Chain.BASE
+        assert intent.native_value_wei == 10**18
+        assert intent.recipient == RECIPIENT
+
+    def test_token_transfer(self):
+        intent = TransactionIntent(
+            chain=Chain.ETHEREUM,
+            action=ActionType.TRANSFER_TOKEN,
+            sender=SENDER,
+            recipient=RECIPIENT,
+            token=TOKEN,
+            amount_base_units=1_000_000,
+            calldata=b"transfer",
+        )
+        assert intent.amount_base_units == 1_000_000
+
+    def test_token_approval(self):
+        intent = TransactionIntent(
+            chain=Chain.ETHEREUM,
+            action=ActionType.APPROVE_TOKEN,
+            sender=SENDER,
+            recipient=RECIPIENT,
+            token=TOKEN,
+            amount_base_units=500,
+            calldata=b"approve",
+        )
+        assert intent.recipient == RECIPIENT
+        assert intent.token == TOKEN
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            ActionType.CONTRACT_CALL,
+            ActionType.SWAP,
+            ActionType.BRIDGE,
+            ActionType.STAKE,
+            ActionType.UNSTAKE,
+            ActionType.GOVERNANCE,
+        ],
+    )
+    def test_contract_actions(self, action):
+        intent = TransactionIntent(
+            chain=Chain.ARBITRUM,
+            action=action,
+            sender=SENDER,
+            contract=CONTRACT,
+            calldata=b"\x12\x34",
+        )
+        assert intent.contract == CONTRACT
+
+    def test_addresses_are_normalized_for_stable_comparison(self):
+        mixed = "0xAbCdEfabcdefABCDefABcdefAbcDEfAbCdEfABcD"
+        intent = native_intent(sender=mixed)
+        assert intent.sender == mixed.lower()
+
+
+class TestValidation:
+    @pytest.mark.parametrize("sender", [None, "", "0x1234", "not-an-address", 123])
+    def test_invalid_sender(self, sender):
+        with pytest.raises(InvalidAddressError):
+            native_intent(sender=sender)
+
+    def test_native_transfer_requires_recipient(self):
+        with pytest.raises(InvalidAddressError, match="recipient is required"):
+            native_intent(recipient=None)
+
+    @pytest.mark.parametrize("field", ["recipient", "token"])
+    def test_token_transfer_requires_recipient_and_token(self, field):
+        values = {
+            "chain": Chain.ETHEREUM,
+            "action": ActionType.TRANSFER_TOKEN,
+            "sender": SENDER,
+            "recipient": RECIPIENT,
+            "token": TOKEN,
+        }
+        values[field] = None
+        with pytest.raises(InvalidAddressError):
+            TransactionIntent(**values)
+
+    @pytest.mark.parametrize("field", ["recipient", "token"])
+    def test_approval_requires_spender_and_token(self, field):
+        values = {
+            "chain": Chain.ETHEREUM,
+            "action": ActionType.APPROVE_TOKEN,
+            "sender": SENDER,
+            "recipient": RECIPIENT,
+            "token": TOKEN,
+        }
+        values[field] = None
+        with pytest.raises(InvalidAddressError):
+            TransactionIntent(**values)
+
+    def test_contract_action_requires_contract(self):
+        with pytest.raises(InvalidAddressError, match="contract is required"):
+            TransactionIntent(
+                chain=Chain.BASE,
+                action=ActionType.CONTRACT_CALL,
+                sender=SENDER,
+            )
+
+    @pytest.mark.parametrize("value", [-1, -10**30, 1.5, "1", True, False, None])
+    @pytest.mark.parametrize("field", ["amount_base_units", "native_value_wei"])
+    def test_amounts_must_be_non_negative_base_unit_integers(self, field, value):
+        with pytest.raises(InvalidAmountError):
+            native_intent(**{field: value})
+
+    @pytest.mark.parametrize("calldata", ["0x1234", bytearray(b"x"), 123, None])
+    def test_calldata_must_be_bytes(self, calldata):
+        with pytest.raises(InvalidCalldataError):
+            native_intent(calldata=calldata)
+
+    def test_action_must_be_enum(self):
+        with pytest.raises(UnsupportedActionError):
+            native_intent(action="transfer_native")
+
+    def test_chain_must_be_enum(self):
+        with pytest.raises(UnsupportedChainError):
+            native_intent(chain="base")
+
+    def test_solana_requires_a_future_chain_specific_intent(self):
+        with pytest.raises(UnsupportedChainError, match="EVM chains only"):
+            native_intent(chain=Chain.SOLANA)
+
+
+class TestImmutability:
+    def test_intent_fields_are_frozen(self):
+        intent = native_intent()
+        with pytest.raises(FrozenInstanceError):
+            intent.native_value_wei = 2  # type: ignore[misc]
+
+    def test_metadata_is_copied_and_recursively_frozen(self):
+        source = {"labels": ["safe"], "nested": {"attempt": 1}}
+        intent = native_intent(metadata=source)
+        source["labels"].append("mutated")
+        source["nested"]["attempt"] = 2
+
+        assert intent.metadata["labels"] == ("safe",)
+        assert intent.metadata["nested"]["attempt"] == 1
+        with pytest.raises(TypeError):
+            intent.metadata["new"] = "value"  # type: ignore[index]
+        with pytest.raises(TypeError):
+            intent.metadata["nested"]["attempt"] = 3  # type: ignore[index]
+
+    def test_metadata_keys_must_be_strings(self):
+        with pytest.raises(InvalidMetadataError, match="keys must be strings"):
+            native_intent(metadata={1: "value"})
+
+    def test_metadata_rejects_arbitrary_objects(self):
+        with pytest.raises(InvalidMetadataError, match="unsupported metadata"):
+            native_intent(metadata={"object": object()})
+
+
+class TestIntentId:
+    def test_id_is_stable_sha256_hex(self):
+        first = native_intent()
+        second = native_intent()
+        assert first.intent_id == second.intent_id
+        assert len(first.intent_id) == 64
+        int(first.intent_id, 16)
+
+    def test_metadata_does_not_change_id(self):
+        assert native_intent(metadata={"label": "a"}).intent_id == native_intent(
+            metadata={"label": "b"}
+        ).intent_id
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"chain": Chain.ARBITRUM},
+            {"recipient": CONTRACT},
+            {"native_value_wei": 2},
+            {"calldata": b"different"},
+        ],
+    )
+    def test_security_fields_change_id(self, override):
+        assert native_intent().intent_id != native_intent(**override).intent_id
+
+
+class TestEvmConversion:
+    def test_from_native_transaction(self):
+        intent = TransactionIntent.from_evm_transaction(
+            chain=Chain.BASE,
+            action=ActionType.TRANSFER_NATIVE,
+            transaction={
+                "from": SENDER,
+                "to": RECIPIENT,
+                "value": 123,
+                "data": "0x1234",
+            },
+        )
+        assert intent.native_value_wei == 123
+        assert intent.calldata == b"\x12\x34"
+
+    def test_contract_call_round_trip(self):
+        tx = {"from": SENDER, "to": CONTRACT, "value": 7, "data": b"\xab\xcd"}
+        intent = TransactionIntent.from_evm_transaction(
+            chain=Chain.ETHEREUM,
+            action=ActionType.CONTRACT_CALL,
+            transaction=tx,
+        )
+        assert intent.to_evm_transaction() == tx
+
+    @pytest.mark.parametrize("data", ["1234", "0xzz", 123])
+    def test_invalid_transaction_calldata(self, data):
+        with pytest.raises(InvalidCalldataError):
+            TransactionIntent.from_evm_transaction(
+                chain=Chain.BASE,
+                action=ActionType.CONTRACT_CALL,
+                transaction={"from": SENDER, "to": CONTRACT, "data": data},
+            )
+
+    @pytest.mark.parametrize(
+        "action", [ActionType.TRANSFER_TOKEN, ActionType.APPROVE_TOKEN]
+    )
+    def test_encoded_token_actions_require_semantic_decoding(self, action):
+        with pytest.raises(InvalidIntentError, match="decoded semantic fields"):
+            TransactionIntent.from_evm_transaction(
+                chain=Chain.BASE,
+                action=action,
+                transaction={"from": SENDER, "to": TOKEN, "data": b"encoded"},
+            )
+
+    def test_transaction_must_be_mapping(self):
+        with pytest.raises(InvalidIntentError, match="must be a mapping"):
+            TransactionIntent.from_evm_transaction(
+                chain=Chain.BASE,
+                action=ActionType.CONTRACT_CALL,
+                transaction=[],
+            )

--- a/web3_agent_kit/__init__.py
+++ b/web3_agent_kit/__init__.py
@@ -31,6 +31,7 @@ from .defi import (
 
 # Events
 from .events import EventConfig, EventListener, Subscription
+from .execution import ActionType, TransactionIntent
 from .gas import GasEstimate, GasOptimizer, GasPriority, GasRecommendation
 
 # Governance
@@ -217,6 +218,9 @@ __all__ = [
     "EventListener",
     "EventConfig",
     "Subscription",
+    # Execution
+    "ActionType",
+    "TransactionIntent",
     # Simulator
     "TxSimulator",
     "SimResult",

--- a/web3_agent_kit/execution/__init__.py
+++ b/web3_agent_kit/execution/__init__.py
@@ -1,0 +1,26 @@
+"""Safety-first transaction execution primitives."""
+
+from .errors import (
+    ExecutionError,
+    InvalidAddressError,
+    InvalidAmountError,
+    InvalidCalldataError,
+    InvalidIntentError,
+    InvalidMetadataError,
+    UnsupportedActionError,
+    UnsupportedChainError,
+)
+from .intent import ActionType, TransactionIntent
+
+__all__ = [
+    "ActionType",
+    "ExecutionError",
+    "InvalidAddressError",
+    "InvalidAmountError",
+    "InvalidCalldataError",
+    "InvalidIntentError",
+    "InvalidMetadataError",
+    "TransactionIntent",
+    "UnsupportedActionError",
+    "UnsupportedChainError",
+]

--- a/web3_agent_kit/execution/errors.py
+++ b/web3_agent_kit/execution/errors.py
@@ -1,0 +1,33 @@
+"""Typed errors raised while creating and validating execution intents."""
+
+
+class ExecutionError(Exception):
+    """Base error for the transaction execution subsystem."""
+
+
+class InvalidIntentError(ExecutionError, ValueError):
+    """Base error for an invalid transaction intent."""
+
+
+class UnsupportedActionError(InvalidIntentError):
+    """Raised when an intent uses an unsupported action."""
+
+
+class UnsupportedChainError(InvalidIntentError):
+    """Raised when an intent targets a chain unsupported by this intent type."""
+
+
+class InvalidAddressError(InvalidIntentError):
+    """Raised when an EVM address is absent or malformed."""
+
+
+class InvalidAmountError(InvalidIntentError):
+    """Raised when an amount is not a non-negative integer in base units."""
+
+
+class InvalidCalldataError(InvalidIntentError):
+    """Raised when calldata is not represented as bytes."""
+
+
+class InvalidMetadataError(InvalidIntentError):
+    """Raised when metadata cannot be copied into an immutable representation."""

--- a/web3_agent_kit/execution/intent.py
+++ b/web3_agent_kit/execution/intent.py
@@ -1,0 +1,234 @@
+"""Immutable transaction intents for deterministic EVM execution planning.
+
+An intent describes what a caller wants to do. It is not authorization to sign
+or broadcast a transaction. Execution policy, simulation, confirmation, and a
+signer remain separate stages of the execution lifecycle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+from ..chains import Chain
+from .errors import (
+    InvalidAddressError,
+    InvalidAmountError,
+    InvalidCalldataError,
+    InvalidIntentError,
+    InvalidMetadataError,
+    UnsupportedActionError,
+    UnsupportedChainError,
+)
+
+_EVM_ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+
+class ActionType(str, Enum):
+    """Supported high-level EVM transaction actions."""
+
+    TRANSFER_NATIVE = "transfer_native"
+    TRANSFER_TOKEN = "transfer_token"
+    APPROVE_TOKEN = "approve_token"
+    CONTRACT_CALL = "contract_call"
+    SWAP = "swap"
+    BRIDGE = "bridge"
+    STAKE = "stake"
+    UNSTAKE = "unstake"
+    GOVERNANCE = "governance"
+
+
+def _normalize_address(value: str | None, field_name: str, *, required: bool) -> str | None:
+    if value is None:
+        if required:
+            raise InvalidAddressError(f"{field_name} is required")
+        return None
+    if not isinstance(value, str) or not _EVM_ADDRESS_PATTERN.fullmatch(value):
+        raise InvalidAddressError(f"{field_name} must be a 20-byte 0x-prefixed EVM address")
+    return value.lower()
+
+
+def _validate_amount(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InvalidAmountError(f"{field_name} must be an integer in base units")
+    if value < 0:
+        raise InvalidAmountError(f"{field_name} cannot be negative")
+    return value
+
+
+def _freeze_metadata(value: Any) -> Any:
+    """Copy supported metadata into recursively immutable containers."""
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise InvalidMetadataError("metadata keys must be strings")
+            frozen[key] = _freeze_metadata(item)
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_metadata(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_metadata(item) for item in value)
+    if value is None or isinstance(value, (str, int, float, bool, bytes)):
+        return value
+    raise InvalidMetadataError(
+        f"unsupported metadata value type: {type(value).__name__}"
+    )
+
+
+@dataclass(frozen=True)
+class TransactionIntent:
+    """A validated, immutable description of a future EVM transaction.
+
+    Amounts are integers in their smallest units. Metadata is excluded from the
+    deterministic intent ID and must never carry security-critical fields.
+    """
+
+    chain: Chain
+    action: ActionType
+    sender: str
+    recipient: str | None = None
+    contract: str | None = None
+    token: str | None = None
+    amount_base_units: int = 0
+    native_value_wei: int = 0
+    calldata: bytes = b""
+    metadata: Mapping[str, Any] = field(default_factory=dict, compare=False, hash=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.chain, Chain):
+            raise UnsupportedChainError("chain must be a Chain enum member")
+        if self.chain == Chain.SOLANA:
+            raise UnsupportedChainError(
+                "TransactionIntent currently supports EVM chains only"
+            )
+        if not isinstance(self.action, ActionType):
+            raise UnsupportedActionError("action must be an ActionType enum member")
+
+        sender = _normalize_address(self.sender, "sender", required=True)
+        recipient = _normalize_address(self.recipient, "recipient", required=False)
+        contract = _normalize_address(self.contract, "contract", required=False)
+        token = _normalize_address(self.token, "token", required=False)
+
+        if self.action == ActionType.TRANSFER_NATIVE and recipient is None:
+            raise InvalidAddressError("recipient is required for a native transfer")
+        if self.action == ActionType.TRANSFER_TOKEN:
+            if recipient is None:
+                raise InvalidAddressError("recipient is required for a token transfer")
+            if token is None:
+                raise InvalidAddressError("token is required for a token transfer")
+        if self.action == ActionType.APPROVE_TOKEN:
+            if recipient is None:
+                raise InvalidAddressError("recipient must identify the approval spender")
+            if token is None:
+                raise InvalidAddressError("token is required for an approval")
+        if self.action in {
+            ActionType.CONTRACT_CALL,
+            ActionType.SWAP,
+            ActionType.BRIDGE,
+            ActionType.STAKE,
+            ActionType.UNSTAKE,
+            ActionType.GOVERNANCE,
+        } and contract is None:
+            raise InvalidAddressError(f"contract is required for {self.action.value}")
+
+        amount = _validate_amount(self.amount_base_units, "amount_base_units")
+        native_value = _validate_amount(self.native_value_wei, "native_value_wei")
+        if not isinstance(self.calldata, bytes):
+            raise InvalidCalldataError("calldata must be bytes")
+        if not isinstance(self.metadata, Mapping):
+            raise InvalidMetadataError("metadata must be a mapping")
+
+        object.__setattr__(self, "sender", sender)
+        object.__setattr__(self, "recipient", recipient)
+        object.__setattr__(self, "contract", contract)
+        object.__setattr__(self, "token", token)
+        object.__setattr__(self, "amount_base_units", amount)
+        object.__setattr__(self, "native_value_wei", native_value)
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+    @property
+    def intent_id(self) -> str:
+        """Return a deterministic SHA-256 ID of security-critical fields."""
+        payload = {
+            "action": self.action.value,
+            "amount_base_units": self.amount_base_units,
+            "calldata": self.calldata.hex(),
+            "chain": self.chain.value,
+            "contract": self.contract,
+            "native_value_wei": self.native_value_wei,
+            "recipient": self.recipient,
+            "sender": self.sender,
+            "token": self.token,
+        }
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def from_evm_transaction(
+        cls,
+        *,
+        chain: Chain,
+        action: ActionType,
+        transaction: Mapping[str, Any],
+        metadata: Mapping[str, Any] | None = None,
+    ) -> TransactionIntent:
+        """Create an intent from a normalized Web3 transaction mapping."""
+        if not isinstance(transaction, Mapping):
+            raise InvalidIntentError("transaction must be a mapping")
+        if action in {ActionType.TRANSFER_TOKEN, ActionType.APPROVE_TOKEN}:
+            raise InvalidIntentError(
+                "token transfers and approvals require decoded semantic fields"
+            )
+        calldata = transaction.get("data", b"")
+        if isinstance(calldata, str):
+            if not calldata.startswith("0x"):
+                raise InvalidCalldataError("hex calldata must start with 0x")
+            try:
+                calldata = bytes.fromhex(calldata[2:])
+            except ValueError as exc:
+                raise InvalidCalldataError("calldata is not valid hexadecimal") from exc
+
+        destination = transaction.get("to")
+        contract_actions = {
+            ActionType.CONTRACT_CALL,
+            ActionType.SWAP,
+            ActionType.BRIDGE,
+            ActionType.STAKE,
+            ActionType.UNSTAKE,
+            ActionType.GOVERNANCE,
+        }
+        return cls(
+            chain=chain,
+            action=action,
+            sender=transaction.get("from"),
+            recipient=destination if action == ActionType.TRANSFER_NATIVE else None,
+            contract=destination if action in contract_actions else None,
+            token=destination
+            if action in {ActionType.TRANSFER_TOKEN, ActionType.APPROVE_TOKEN}
+            else None,
+            native_value_wei=transaction.get("value", 0),
+            calldata=calldata,
+            metadata=metadata or {},
+        )
+
+    def to_evm_transaction(self) -> dict[str, Any]:
+        """Return the normalized transaction fields represented by this intent."""
+        if self.action in {ActionType.TRANSFER_TOKEN, ActionType.APPROVE_TOKEN}:
+            destination = self.token
+        else:
+            destination = self.contract or self.recipient
+        transaction: dict[str, Any] = {
+            "from": self.sender,
+            "value": self.native_value_wei,
+            "data": self.calldata,
+        }
+        if destination is not None:
+            transaction["to"] = destination
+        return transaction


### PR DESCRIPTION
### Motivation

- Introduce a safety-first, immutable representation of planned EVM transactions to centralize validation and deterministic identity for execution planning.
- Provide typed, specific errors to make intent validation failures explicit and machine-detectable.
- Add offline unit tests to exercise validation, immutability, canonical ID generation, and EVM conversion routines.

### Description

- Add a new `web3_agent_kit.execution` package that exposes `ActionType`, `TransactionIntent`, and typed errors via `errors.py` and `intent.py`.
- Implement `TransactionIntent` as a frozen `@dataclass` with strict address/amount/calldata/metadata validation, recursive metadata freezing, and a deterministic SHA-256 `intent_id` that excludes metadata.
- Implement `from_evm_transaction` and `to_evm_transaction` helpers for normalized round-trip conversion between intents and EVM transaction mappings.
- Export `ActionType` and `TransactionIntent` from the top-level `web3_agent_kit` package by updating `__init__.py` and add comprehensive tests in `tests/test_execution_intent.py` covering validation, immutability, id stability, and conversion behavior.

### Testing

- Added `tests/test_execution_intent.py` with offline unit tests exercising validation, immutability, metadata freezing, intent ID semantics, and EVM conversion.
- Ran the new test suite with `pytest tests/test_execution_intent.py` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2940bca88331ab473317720a70b7)