### PR TITLE
Add deterministic ExecutionPolicy with validation and tests

### DIFF
--- a/tests/test_execution_policy.py
+++ b/tests/test_execution_policy.py
@@ -1,0 +1,309 @@
+"""Offline tests for deterministic transaction execution policy."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from web3_agent_kit.chains import Chain
+from web3_agent_kit.execution import ActionType, TransactionIntent
+from web3_agent_kit.execution.policy import (
+    UINT256_MAX,
+    ExecutionPolicy,
+    InvalidPolicyAllowlistError,
+    InvalidPolicyError,
+    InvalidPolicyLimitError,
+    PolicyDecision,
+    PolicyReason,
+)
+
+SENDER = "0x1111111111111111111111111111111111111111"
+RECIPIENT = "0x2222222222222222222222222222222222222222"
+CONTRACT = "0x3333333333333333333333333333333333333333"
+TOKEN = "0x4444444444444444444444444444444444444444"
+OTHER = "0x5555555555555555555555555555555555555555"
+
+
+def policy(**overrides) -> ExecutionPolicy:
+    values = {
+        "allowed_chains": {Chain.BASE},
+        "allowed_actions": set(ActionType),
+        "allowed_contracts": {CONTRACT},
+        "allowed_tokens": {TOKEN},
+        "max_native_value_wei": 100,
+        "max_token_amounts": {TOKEN: 1_000},
+        "max_approval_amounts": {TOKEN: 500},
+        "require_confirmation": True,
+    }
+    values.update(overrides)
+    return ExecutionPolicy(**values)
+
+
+def native_intent(**overrides) -> TransactionIntent:
+    values = {
+        "chain": Chain.BASE,
+        "action": ActionType.TRANSFER_NATIVE,
+        "sender": SENDER,
+        "recipient": RECIPIENT,
+        "native_value_wei": 100,
+    }
+    values.update(overrides)
+    return TransactionIntent(**values)
+
+
+def token_intent(action=ActionType.TRANSFER_TOKEN, **overrides) -> TransactionIntent:
+    values = {
+        "chain": Chain.BASE,
+        "action": action,
+        "sender": SENDER,
+        "recipient": RECIPIENT,
+        "token": TOKEN,
+        "amount_base_units": 500,
+        "calldata": b"encoded",
+    }
+    values.update(overrides)
+    return TransactionIntent(**values)
+
+
+class TestAllowedDecisions:
+    def test_native_transfer_at_limit_is_allowed(self):
+        intent = native_intent(native_value_wei=100)
+        decision = policy().evaluate(intent)
+        assert decision.allowed is True
+        assert decision.reasons == ()
+        assert decision.intent_id == intent.intent_id
+        assert decision.requires_confirmation is True
+        assert decision.primary_reason is None
+
+    def test_token_transfer_at_limit_is_allowed(self):
+        decision = policy().evaluate(token_intent(amount_base_units=1_000))
+        assert decision.allowed
+
+    def test_approval_at_limit_is_allowed(self):
+        decision = policy().evaluate(
+            token_intent(ActionType.APPROVE_TOKEN, amount_base_units=500)
+        )
+        assert decision.allowed
+
+    def test_contract_call_with_allowlisted_contract_is_allowed(self):
+        intent = TransactionIntent(
+            chain=Chain.BASE,
+            action=ActionType.CONTRACT_CALL,
+            sender=SENDER,
+            contract=CONTRACT,
+            calldata=b"call",
+        )
+        assert policy().evaluate(intent).allowed
+
+    def test_confirmation_is_separate_from_authorization(self):
+        decision = policy(require_confirmation=False).evaluate(native_intent())
+        assert decision.allowed
+        assert decision.requires_confirmation is False
+
+
+class TestDeniedDecisions:
+    def test_deny_all_policy(self):
+        decision = ExecutionPolicy.deny_all().evaluate(native_intent())
+        assert not decision.allowed
+        assert decision.reasons == (
+            PolicyReason.CHAIN_NOT_ALLOWED,
+            PolicyReason.ACTION_NOT_ALLOWED,
+            PolicyReason.NATIVE_VALUE_EXCEEDED,
+        )
+
+    def test_chain_not_allowed(self):
+        decision = policy(allowed_chains={Chain.ETHEREUM}).evaluate(native_intent())
+        assert decision.reasons == (PolicyReason.CHAIN_NOT_ALLOWED,)
+
+    def test_action_not_allowed(self):
+        decision = policy(allowed_actions={ActionType.SWAP}).evaluate(native_intent())
+        assert decision.reasons == (PolicyReason.ACTION_NOT_ALLOWED,)
+
+    def test_contract_not_allowed(self):
+        intent = TransactionIntent(
+            chain=Chain.BASE,
+            action=ActionType.CONTRACT_CALL,
+            sender=SENDER,
+            contract=OTHER,
+        )
+        decision = policy().evaluate(intent)
+        assert decision.reasons == (PolicyReason.CONTRACT_NOT_ALLOWED,)
+
+    def test_token_not_allowed(self):
+        intent = token_intent(token=OTHER)
+        decision = policy(max_token_amounts={OTHER: 1_000}).evaluate(intent)
+        assert decision.reasons == (PolicyReason.TOKEN_NOT_ALLOWED,)
+
+    def test_native_value_above_limit(self):
+        decision = policy().evaluate(native_intent(native_value_wei=101))
+        assert decision.reasons == (PolicyReason.NATIVE_VALUE_EXCEEDED,)
+
+    def test_missing_token_limit_fails_closed(self):
+        decision = policy(max_token_amounts={}).evaluate(token_intent())
+        assert decision.reasons == (PolicyReason.TOKEN_LIMIT_NOT_CONFIGURED,)
+
+    def test_token_amount_above_limit(self):
+        decision = policy().evaluate(token_intent(amount_base_units=1_001))
+        assert decision.reasons == (PolicyReason.TOKEN_AMOUNT_EXCEEDED,)
+
+    def test_missing_approval_limit_fails_closed(self):
+        decision = policy(max_approval_amounts={}).evaluate(
+            token_intent(ActionType.APPROVE_TOKEN)
+        )
+        assert decision.reasons == (PolicyReason.APPROVAL_LIMIT_NOT_CONFIGURED,)
+
+    def test_approval_amount_above_limit(self):
+        decision = policy().evaluate(
+            token_intent(ActionType.APPROVE_TOKEN, amount_base_units=501)
+        )
+        assert decision.reasons == (PolicyReason.APPROVAL_AMOUNT_EXCEEDED,)
+
+    def test_unlimited_approval_is_denied_by_default(self):
+        decision = policy(max_approval_amounts={TOKEN: UINT256_MAX}).evaluate(
+            token_intent(ActionType.APPROVE_TOKEN, amount_base_units=UINT256_MAX)
+        )
+        assert decision.reasons == (PolicyReason.UNLIMITED_APPROVAL_DENIED,)
+
+    def test_unlimited_approval_may_be_explicitly_enabled(self):
+        decision = policy(
+            max_approval_amounts={TOKEN: UINT256_MAX},
+            deny_unlimited_approval=False,
+        ).evaluate(
+            token_intent(ActionType.APPROVE_TOKEN, amount_base_units=UINT256_MAX)
+        )
+        assert decision.allowed
+
+    def test_collects_all_reasons_in_stable_order(self):
+        intent = TransactionIntent(
+            chain=Chain.ARBITRUM,
+            action=ActionType.APPROVE_TOKEN,
+            sender=SENDER,
+            recipient=RECIPIENT,
+            token=OTHER,
+            amount_base_units=UINT256_MAX,
+            native_value_wei=101,
+        )
+        decision = policy(allowed_actions={ActionType.TRANSFER_NATIVE}).evaluate(intent)
+        assert decision.reasons == (
+            PolicyReason.CHAIN_NOT_ALLOWED,
+            PolicyReason.ACTION_NOT_ALLOWED,
+            PolicyReason.TOKEN_NOT_ALLOWED,
+            PolicyReason.NATIVE_VALUE_EXCEEDED,
+            PolicyReason.APPROVAL_LIMIT_NOT_CONFIGURED,
+            PolicyReason.UNLIMITED_APPROVAL_DENIED,
+        )
+        assert decision.primary_reason == PolicyReason.CHAIN_NOT_ALLOWED
+        assert decision.has_reason(PolicyReason.UNLIMITED_APPROVAL_DENIED)
+
+
+class TestPolicyConfiguration:
+    def test_source_collections_are_copied(self):
+        chains = {Chain.BASE}
+        actions = {ActionType.TRANSFER_NATIVE}
+        contracts = {CONTRACT}
+        tokens = {TOKEN}
+        token_limits = {TOKEN: 10}
+        configured = policy(
+            allowed_chains=chains,
+            allowed_actions=actions,
+            allowed_contracts=contracts,
+            allowed_tokens=tokens,
+            max_token_amounts=token_limits,
+        )
+
+        chains.add(Chain.ETHEREUM)
+        actions.add(ActionType.SWAP)
+        contracts.add(OTHER)
+        tokens.add(OTHER)
+        token_limits[TOKEN] = 999
+
+        assert configured.allowed_chains == frozenset({Chain.BASE})
+        assert configured.allowed_actions == frozenset({ActionType.TRANSFER_NATIVE})
+        assert configured.allowed_contracts == frozenset({CONTRACT})
+        assert configured.allowed_tokens == frozenset({TOKEN})
+        assert configured.max_token_amounts[TOKEN] == 10
+
+    def test_addresses_are_normalized(self):
+        mixed = "0xAbCdEfabcdefABCDefABcdefAbcDEfAbCdEfABcD"
+        configured = policy(
+            allowed_contracts={mixed},
+            allowed_tokens={mixed},
+            max_token_amounts={mixed: 1},
+            max_approval_amounts={mixed: 1},
+        )
+        normalized = mixed.lower()
+        assert configured.allowed_contracts == frozenset({normalized})
+        assert configured.allowed_tokens == frozenset({normalized})
+        assert configured.max_token_amounts[normalized] == 1
+
+    @pytest.mark.parametrize("field", ["allowed_chains", "allowed_actions"])
+    def test_typed_allowlists_reject_strings(self, field):
+        with pytest.raises(InvalidPolicyAllowlistError):
+            policy(**{field: {"base"}})
+
+    @pytest.mark.parametrize("field", ["allowed_contracts", "allowed_tokens"])
+    @pytest.mark.parametrize("value", [{"bad"}, "bad", {123}])
+    def test_address_allowlists_reject_invalid_values(self, field, value):
+        with pytest.raises(InvalidPolicyAllowlistError):
+            policy(**{field: value})
+
+    @pytest.mark.parametrize(
+        "field", ["max_native_value_wei", "max_token_amounts", "max_approval_amounts"]
+    )
+    @pytest.mark.parametrize("value", [-1, 1.5, "1", True, False, None])
+    def test_limits_reject_non_base_unit_values(self, field, value):
+        configured_value = value if field == "max_native_value_wei" else {TOKEN: value}
+        with pytest.raises(InvalidPolicyLimitError):
+            policy(**{field: configured_value})
+
+    @pytest.mark.parametrize("field", ["max_token_amounts", "max_approval_amounts"])
+    def test_limit_maps_reject_invalid_addresses(self, field):
+        with pytest.raises(InvalidPolicyAllowlistError):
+            policy(**{field: {"bad": 1}})
+
+    def test_duplicate_normalized_limit_addresses_are_rejected(self):
+        mixed = "0xAbCdEfabcdefABCDefABcdefAbcDEfAbCdEfABcD"
+        with pytest.raises(InvalidPolicyLimitError, match="duplicate normalized"):
+            policy(max_token_amounts={mixed: 1, mixed.lower(): 2})
+
+    @pytest.mark.parametrize(
+        "field", ["deny_unlimited_approval", "require_confirmation"]
+    )
+    def test_boolean_configuration_is_strict(self, field):
+        with pytest.raises(InvalidPolicyError):
+            policy(**{field: 1})
+
+    def test_policy_is_frozen(self):
+        configured = policy()
+        with pytest.raises(FrozenInstanceError):
+            configured.max_native_value_wei = 1  # type: ignore[misc]
+        with pytest.raises(TypeError):
+            configured.max_token_amounts[TOKEN] = 1  # type: ignore[index]
+
+    def test_evaluate_requires_intent(self):
+        with pytest.raises(InvalidPolicyError, match="TransactionIntent"):
+            policy().evaluate(object())
+
+
+class TestPolicyDecisionValidation:
+    def test_denied_decision_requires_reason(self):
+        with pytest.raises(InvalidPolicyError, match="requires at least one"):
+            PolicyDecision(False, (), "intent")
+
+    def test_allowed_decision_rejects_reasons(self):
+        with pytest.raises(InvalidPolicyError, match="cannot contain"):
+            PolicyDecision(True, (PolicyReason.CHAIN_NOT_ALLOWED,), "intent")
+
+    def test_duplicate_reasons_are_rejected(self):
+        with pytest.raises(InvalidPolicyError, match="duplicates"):
+            PolicyDecision(
+                False,
+                (PolicyReason.CHAIN_NOT_ALLOWED, PolicyReason.CHAIN_NOT_ALLOWED),
+                "intent",
+            )
+
+    @pytest.mark.parametrize("intent_id", ["", None, 123])
+    def test_intent_id_is_required(self, intent_id):
+        with pytest.raises(InvalidPolicyError):
+            PolicyDecision(True, (), intent_id)

--- a/web3_agent_kit/execution/policy.py
+++ b/web3_agent_kit/execution/policy.py
@@ -1,0 +1,236 @@
+"""Deterministic, offline authorization policy for transaction intents."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+
+from ..chains import Chain
+from .errors import ExecutionError
+from .intent import ActionType, TransactionIntent
+
+__all__ = [
+    "ExecutionPolicy",
+    "InvalidPolicyAllowlistError",
+    "InvalidPolicyError",
+    "InvalidPolicyLimitError",
+    "PolicyDecision",
+    "PolicyReason",
+    "UINT256_MAX",
+]
+
+UINT256_MAX = 2**256 - 1
+_EVM_ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+
+class InvalidPolicyError(ExecutionError, ValueError):
+    """Base error for invalid execution policy configuration."""
+
+
+class InvalidPolicyAllowlistError(InvalidPolicyError):
+    """Raised when a policy allowlist contains an invalid value."""
+
+
+class InvalidPolicyLimitError(InvalidPolicyError):
+    """Raised when a policy limit is absent or malformed."""
+
+
+class PolicyReason(str, Enum):
+    """Stable, machine-readable reasons for a policy denial."""
+
+    CHAIN_NOT_ALLOWED = "chain_not_allowed"
+    ACTION_NOT_ALLOWED = "action_not_allowed"
+    CONTRACT_NOT_ALLOWED = "contract_not_allowed"
+    TOKEN_NOT_ALLOWED = "token_not_allowed"
+    NATIVE_VALUE_EXCEEDED = "native_value_exceeded"
+    TOKEN_LIMIT_NOT_CONFIGURED = "token_limit_not_configured"
+    TOKEN_AMOUNT_EXCEEDED = "token_amount_exceeded"
+    APPROVAL_LIMIT_NOT_CONFIGURED = "approval_limit_not_configured"
+    APPROVAL_AMOUNT_EXCEEDED = "approval_amount_exceeded"
+    UNLIMITED_APPROVAL_DENIED = "unlimited_approval_denied"
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Immutable result of evaluating one intent against one policy."""
+
+    allowed: bool
+    reasons: tuple[PolicyReason, ...]
+    intent_id: str
+    requires_confirmation: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.allowed, bool):
+            raise InvalidPolicyError("allowed must be a boolean")
+        if not isinstance(self.requires_confirmation, bool):
+            raise InvalidPolicyError("requires_confirmation must be a boolean")
+        if not isinstance(self.intent_id, str) or not self.intent_id:
+            raise InvalidPolicyError("intent_id must be a non-empty string")
+        if not isinstance(self.reasons, tuple) or any(
+            not isinstance(reason, PolicyReason) for reason in self.reasons
+        ):
+            raise InvalidPolicyError("reasons must be a tuple of PolicyReason values")
+        if len(set(self.reasons)) != len(self.reasons):
+            raise InvalidPolicyError("reasons cannot contain duplicates")
+        if self.allowed and self.reasons:
+            raise InvalidPolicyError("an allowed decision cannot contain denial reasons")
+        if not self.allowed and not self.reasons:
+            raise InvalidPolicyError("a denied decision requires at least one reason")
+
+    @property
+    def primary_reason(self) -> PolicyReason | None:
+        """Return the first denial reason, if any."""
+        return self.reasons[0] if self.reasons else None
+
+    def has_reason(self, reason: PolicyReason) -> bool:
+        """Return whether this decision includes a specific denial reason."""
+        return reason in self.reasons
+
+
+def _copy_typed_set(
+    values: Iterable[object], expected_type: type, field_name: str
+) -> frozenset:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Iterable):
+        raise InvalidPolicyAllowlistError(f"{field_name} must be an iterable")
+    copied = frozenset(values)
+    if any(not isinstance(value, expected_type) for value in copied):
+        raise InvalidPolicyAllowlistError(
+            f"{field_name} must contain only {expected_type.__name__} values"
+        )
+    return copied
+
+
+def _normalize_address(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not _EVM_ADDRESS_PATTERN.fullmatch(value):
+        raise InvalidPolicyAllowlistError(
+            f"{field_name} keys must be 20-byte 0x-prefixed EVM addresses"
+        )
+    return value.lower()
+
+
+def _copy_address_set(values: Iterable[object], field_name: str) -> frozenset[str]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Iterable):
+        raise InvalidPolicyAllowlistError(f"{field_name} must be an iterable")
+    return frozenset(_normalize_address(value, field_name) for value in values)
+
+
+def _validate_limit(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InvalidPolicyLimitError(f"{field_name} must be an integer in base units")
+    if value < 0:
+        raise InvalidPolicyLimitError(f"{field_name} cannot be negative")
+    return value
+
+
+def _copy_limit_mapping(
+    values: Mapping[object, object], field_name: str
+) -> Mapping[str, int]:
+    if not isinstance(values, Mapping):
+        raise InvalidPolicyLimitError(f"{field_name} must be a mapping")
+    copied: dict[str, int] = {}
+    for address, limit in values.items():
+        normalized = _normalize_address(address, field_name)
+        validated = _validate_limit(limit, f"{field_name}[{normalized}]")
+        if normalized in copied:
+            raise InvalidPolicyLimitError(
+                f"{field_name} contains duplicate normalized address {normalized}"
+            )
+        copied[normalized] = validated
+    return MappingProxyType(copied)
+
+
+@dataclass(frozen=True)
+class ExecutionPolicy:
+    """Fail-closed allowlists and limits for EVM transaction intents.
+
+    Empty allowlists deny all matching resources; they never mean unrestricted.
+    Policy evaluation is deterministic and performs no network operations.
+    """
+
+    allowed_chains: frozenset[Chain]
+    allowed_actions: frozenset[ActionType]
+    allowed_contracts: frozenset[str] = frozenset()
+    allowed_tokens: frozenset[str] = frozenset()
+    max_native_value_wei: int = 0
+    max_token_amounts: Mapping[str, int] = field(default_factory=dict)
+    max_approval_amounts: Mapping[str, int] = field(default_factory=dict)
+    deny_unlimited_approval: bool = True
+    require_confirmation: bool = True
+
+    def __post_init__(self) -> None:
+        chains = _copy_typed_set(self.allowed_chains, Chain, "allowed_chains")
+        actions = _copy_typed_set(self.allowed_actions, ActionType, "allowed_actions")
+        contracts = _copy_address_set(self.allowed_contracts, "allowed_contracts")
+        tokens = _copy_address_set(self.allowed_tokens, "allowed_tokens")
+        native_limit = _validate_limit(self.max_native_value_wei, "max_native_value_wei")
+        token_limits = _copy_limit_mapping(self.max_token_amounts, "max_token_amounts")
+        approval_limits = _copy_limit_mapping(
+            self.max_approval_amounts, "max_approval_amounts"
+        )
+        if not isinstance(self.deny_unlimited_approval, bool):
+            raise InvalidPolicyError("deny_unlimited_approval must be a boolean")
+        if not isinstance(self.require_confirmation, bool):
+            raise InvalidPolicyError("require_confirmation must be a boolean")
+
+        object.__setattr__(self, "allowed_chains", chains)
+        object.__setattr__(self, "allowed_actions", actions)
+        object.__setattr__(self, "allowed_contracts", contracts)
+        object.__setattr__(self, "allowed_tokens", tokens)
+        object.__setattr__(self, "max_native_value_wei", native_limit)
+        object.__setattr__(self, "max_token_amounts", token_limits)
+        object.__setattr__(self, "max_approval_amounts", approval_limits)
+
+    @classmethod
+    def deny_all(cls, *, require_confirmation: bool = True) -> ExecutionPolicy:
+        """Return an explicit policy that denies every transaction intent."""
+        return cls(
+            allowed_chains=frozenset(),
+            allowed_actions=frozenset(),
+            require_confirmation=require_confirmation,
+        )
+
+    def evaluate(self, intent: TransactionIntent) -> PolicyDecision:
+        """Evaluate all rules and return every applicable denial reason."""
+        if not isinstance(intent, TransactionIntent):
+            raise InvalidPolicyError("intent must be a TransactionIntent")
+
+        reasons: list[PolicyReason] = []
+        if intent.chain not in self.allowed_chains:
+            reasons.append(PolicyReason.CHAIN_NOT_ALLOWED)
+        if intent.action not in self.allowed_actions:
+            reasons.append(PolicyReason.ACTION_NOT_ALLOWED)
+        if intent.contract is not None and intent.contract not in self.allowed_contracts:
+            reasons.append(PolicyReason.CONTRACT_NOT_ALLOWED)
+        if intent.token is not None and intent.token not in self.allowed_tokens:
+            reasons.append(PolicyReason.TOKEN_NOT_ALLOWED)
+        if intent.native_value_wei > self.max_native_value_wei:
+            reasons.append(PolicyReason.NATIVE_VALUE_EXCEEDED)
+
+        if intent.action == ActionType.TRANSFER_TOKEN:
+            token_limit = self.max_token_amounts.get(intent.token)
+            if token_limit is None:
+                reasons.append(PolicyReason.TOKEN_LIMIT_NOT_CONFIGURED)
+            elif intent.amount_base_units > token_limit:
+                reasons.append(PolicyReason.TOKEN_AMOUNT_EXCEEDED)
+
+        if intent.action == ActionType.APPROVE_TOKEN:
+            approval_limit = self.max_approval_amounts.get(intent.token)
+            if approval_limit is None:
+                reasons.append(PolicyReason.APPROVAL_LIMIT_NOT_CONFIGURED)
+            elif intent.amount_base_units > approval_limit:
+                reasons.append(PolicyReason.APPROVAL_AMOUNT_EXCEEDED)
+            if (
+                self.deny_unlimited_approval
+                and intent.amount_base_units == UINT256_MAX
+            ):
+                reasons.append(PolicyReason.UNLIMITED_APPROVAL_DENIED)
+
+        return PolicyDecision(
+            allowed=not reasons,
+            reasons=tuple(reasons),
+            intent_id=intent.intent_id,
+            requires_confirmation=self.require_confirmation,
+        )


### PR DESCRIPTION
### Motivation

- Provide a deterministic, offline authorization policy for EVM transaction intents to enforce fail-closed allowlists and limits. 
- Ensure policy configuration is validated and immutable to avoid runtime surprises and security gaps. 
- Capture stable, machine-readable denial reasons and a clear evaluation result for downstream consumers.

### Description

- Add `web3_agent_kit.execution.policy` implementing `ExecutionPolicy`, `PolicyDecision`, `PolicyReason`, `UINT256_MAX`, and validation error types. 
- Implement typed allowlists, address normalization, integer limit validation, mapping copying via `_copy_*` helpers, and strict config validation in `ExecutionPolicy.__post_init__`. 
- Implement `ExecutionPolicy.evaluate` and `ExecutionPolicy.deny_all` to deterministically collect all applicable denial reasons and return an immutable `PolicyDecision`. 
- Add comprehensive unit tests in `tests/test_execution_policy.py` covering allowed/denied decisions, configuration validation, normalization/immutability, and `PolicyDecision` invariants.

### Testing

- Ran the new unit test module with `pytest tests/test_execution_policy.py`. 
- All tests in `tests/test_execution_policy.py` passed. 
- The tests exercise allowed and denied scenarios, configuration validation errors, address normalization, and decision validation rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2940bca88331ab473317720a70b7)