### PR TITLE
chore: sync package homepage with Vercel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ api = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ulsreall/web3-agent-kit"
+Homepage = "https://web3-agent-kit.vercel.app/"
 Repository = "https://github.com/ulsreall/web3-agent-kit"
 Issues = "https://github.com/ulsreall/web3-agent-kit/issues"
 Documentation = "https://ulsreall.github.io/web3-agent-kit/"


### PR DESCRIPTION
Update PyPI project metadata so Homepage matches the active Vercel deployment. Repository and Documentation URLs remain canonical GitHub/GitHub Pages links.