### PR TITLE
chore: prepare v1.16.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-08-14
+
+### Changed
+
+- Synced the PyPI project homepage with the active Vercel deployment.
+
 ## [1.16.0] - 2026-08-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "web3-agent-kit"
-version = "1.16.0"
+version = "1.16.1"
 description = "Open-source framework for building autonomous AI agents that interact with blockchain networks"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ api = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ulsreall/web3-agent-kit"
+Homepage = "https://web3-agent-kit.vercel.app/"
 Repository = "https://github.com/ulsreall/web3-agent-kit"
 Issues = "https://github.com/ulsreall/web3-agent-kit/issues"
 Documentation = "https://ulsreall.github.io/web3-agent-kit/"

--- a/web3_agent_kit/__init__.py
+++ b/web3_agent_kit/__init__.py
@@ -1,6 +1,6 @@
 """Web3 Agent Kit — Open-source framework for autonomous Web3 AI agents."""
 
-__version__ = "1.16.0"
+__version__ = "1.16.1"
 __author__ = "Maulana"
 
 # Core


### PR DESCRIPTION
Synchronize package version and publish the corrected PyPI homepage metadata. This is a metadata-only patch release.