### PR TITLE
docs: sync v1.16.1 project statistics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> **Current version:** v1.16.0
+> **Current version:** v1.16.1
 > **Updated:** 2026-08-10
 > **Modules:** 25  
 > **Tests:** 1,791+ (70% coverage gate)

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,15 +36,15 @@ pip install web3-agent-kit
 <!-- Stats Bar -->
 <div class="tx-stats" markdown>
 <div class="stat" markdown>
-<div class="stat-num">v1.16.0</div>
+<div class="stat-num">v1.16.1</div>
 <div class="stat-label">Version</div>
 </div>
 <div class="stat" markdown>
-<div class="stat-num">24+</div>
+<div class="stat-num">25</div>
 <div class="stat-label">Modules</div>
 </div>
 <div class="stat" markdown>
-<div class="stat-num">1,225</div>
+<div class="stat-num">1,791</div>
 <div class="stat-label">Tests</div>
 </div>
 <div class="stat" markdown>


### PR DESCRIPTION
Synchronize the roadmap and GitHub Pages stats with the released package: v1.16.1, 25 modules, and 1,791 tests.