### PR TITLE
feat: redesign documentation site theme

### DIFF
--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#101512"/>
+  <path d="M13 18 23 46 32 27l9 19 10-28" fill="none" stroke="#3ddc97" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="13" cy="18" r="4" fill="#f0f2ed"/>
+  <circle cx="32" cy="27" r="4" fill="#3ddc97"/>
+  <circle cx="52" cy="18" r="4" fill="#f0f2ed"/>
+</svg>

--- a/docs/assets/logo-mark.svg
+++ b/docs/assets/logo-mark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">Web3 Agent Kit</title>
+  <rect width="64" height="64" rx="14" fill="#101512"/>
+  <path d="M13 18 23 46 32 27l9 19 10-28" fill="none" stroke="#3ddc97" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="13" cy="18" r="4" fill="#f0f2ed"/>
+  <circle cx="32" cy="27" r="4" fill="#3ddc97"/>
+  <circle cx="52" cy="18" r="4" fill="#f0f2ed"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,312 +1,156 @@
---- 
-title: Web3 Agent Kit
-description: Build autonomous AI agents that interact with blockchains — in minutes, not months.
-hide:
-  - navigation
-  - toc
-  - title
----
+<div class="docs-hero" markdown>
+<div class="docs-hero-copy" markdown>
 
-<!-- Hero Section -->
-<div class="tx-hero tx-hero-gradient" markdown>
+<p class="docs-eyebrow">OPEN-SOURCE PYTHON INFRASTRUCTURE <span>·</span> v1.16.1</p>
 
-# Web3 Agent Kit
+# Build agents that can actually execute.
 
-<div class="tx-hero-sub" markdown>
+Web3 Agent Kit gives autonomous agents a controlled path from intent to on-chain execution: wallets, chains, protocol tools, transaction simulation, and operator-defined policy in one Python framework.
 
-Build autonomous AI agents that interact with blockchains — **in minutes, not months.**
-
+<div class="docs-actions" markdown>
+[Get started](getting-started.md){ .md-button .md-button--primary }
+[View source](https://github.com/ulsreall/web3-agent-kit){ .md-button }
 </div>
 
-<div class="tx-hero-code" markdown>
-
-```bash
-pip install web3-agent-kit
-```
-
-</div>
-
-<div class="tx-hero-buttons" markdown>
-[Get Started](getting-started.md){ .md-button .md-button--primary }
-[View on GitHub](https://github.com/ulsreall/web3-agent-kit){ .md-button }
+<div class="docs-install" markdown>
+<span>INSTALL</span>
+`pip install web3-agent-kit`
 </div>
 
 </div>
 
-<!-- Stats Bar -->
-<div class="tx-stats" markdown>
-<div class="stat" markdown>
-<div class="stat-num">v1.16.1</div>
-<div class="stat-label">Version</div>
-</div>
-<div class="stat" markdown>
-<div class="stat-num">25</div>
-<div class="stat-label">Modules</div>
-</div>
-<div class="stat" markdown>
-<div class="stat-num">1,791</div>
-<div class="stat-label">Tests</div>
-</div>
-<div class="stat" markdown>
-<div class="stat-num">8</div>
-<div class="stat-label">Chains</div>
-</div>
-<div class="stat" markdown>
-<div class="stat-num">MIT</div>
-<div class="stat-label">License</div>
-</div>
-</div>
-
-<!-- One-liner Demo -->
-<div class="tx-divider"></div>
-
-## 🚀 From Zero to Agent in 5 Lines
+<div class="docs-terminal" markdown>
+<div class="terminal-bar"><span></span><span></span><span></span><b>agent.py</b><i>READY</i></div>
 
 ```python
 from web3_agent_kit import Agent, Wallet, Chain
 from web3_agent_kit.defi import Uniswap
 
-agent = Agent(wallet=Wallet.from_env("PRIVATE_KEY"), chains=[Chain.BASE], tools=[Uniswap()])
-result = agent.run("Swap 0.1 ETH to USDC on Base")
+agent = Agent(
+    wallet=Wallet.from_env("PRIVATE_KEY"),
+    chains=[Chain.BASE],
+    tools=[Uniswap()],
+)
+
+result = agent.run("check my balances")
 print(result)
 ```
 
-Or use the **CLI** — no Python needed:
-
-```bash
-wak agent --goal "Swap 0.1 ETH to USDC on Base" --wallet 0x...
-```
-
-<div class="tx-divider"></div>
-
-## ✨ Everything You Need
-
-<div class="tx-features" markdown>
-
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🤖</span>
-### Agent Framework
-Goal-driven autonomous agents with LLM reasoning. Natural language in, on-chain actions out.
+<div class="terminal-foot">intent → policy → simulation → execution</div>
+</div>
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">💰</span>
-### DeFi Tools
-Uniswap V2/V3, Aerodrome, Aave, Curve. Real swaps, quotes, approvals, slippage protection.
+<div class="docs-metrics" markdown>
+<div><strong>25</strong><span>modules</span></div>
+<div><strong>1,791</strong><span>tests passing</span></div>
+<div><strong>8</strong><span>supported chains</span></div>
+<div><strong>74%</strong><span>coverage</span></div>
+<div><strong>MIT</strong><span>license</span></div>
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🎯</span>
-### Airdrop Suite
-Galxe, Zealy, Layer3, Gleam, QuestN, Intract. Multi-wallet farming, auto-discovery.
+<div class="docs-rule"></div>
+
+<div class="docs-section-intro" markdown>
+<p class="docs-section-number">01 / THE FRAMEWORK</p>
+
+## Everything around the transaction.
+
+The hard part of an on-chain agent is not calling a contract. It is making the full path observable, composable, and safe to operate. The kit keeps those concerns in one surface.
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🔐</span>
-### Security Audit
-Static analysis, fuzzing, exploit PoC, forensics. 10 specialized audit skills built-in.
+<div class="docs-capabilities" markdown>
+<div class="docs-capability" markdown>
+<span class="capability-number">01</span>
+### Agent runtime
+
+Goal-driven execution with pluggable LLM providers, tool routing, structured results, and a Python API that stays readable.
+
+[Read the agent API →](api/agent.md)
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">⚡</span>
-### MEV Bots
-Cross-DEX arbitrage, liquidation bot, Flashbot support. Extract value from mempool.
+<div class="docs-capability docs-capability-dark" markdown>
+<span class="capability-number">02</span>
+### Execution policy
+
+Spend limits, operator confirmation, kill switches, and transaction simulation sit between an agent decision and a broadcast.
+
+[Review the security model →](security-model.md)
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🖼️</span>
-### NFT Tools
-Deploy collections, batch mint, marketplace listing. ERC-721A optimized.
+<div class="docs-capability" markdown>
+<span class="capability-number">03</span>
+### Protocol primitives
+
+DeFi, bridges, wallets, gas, portfolio, NFT, trading, oracle, and account-abstraction modules share the same chain-aware foundation.
+
+[Explore features →](features.md)
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">📈</span>
-### Trading Bots
-DCA with price triggers, yield optimizer, token sniper. Automated strategies.
+<div class="docs-capability docs-capability-wide" markdown>
+<span class="capability-number">04</span>
+### Multi-chain by default
+
+Use one interface across Ethereum, Base, Arbitrum, Polygon, Optimism, BSC, Solana, and Avalanche. Add a new chain without rebuilding every tool around it.
+
+<div class="chain-list"><span>Ethereum</span><span>Base</span><span>Arbitrum</span><span>Polygon</span><span>Optimism</span><span>BSC</span><span>Solana</span><span>Avalanche</span></div>
+</div>
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🌉</span>
-### Cross-Chain Bridge
-Li.Fi + Socket aggregators. Best routes, lowest fees, 8 chains.
+<div class="docs-rule"></div>
+
+<div class="docs-section-intro" markdown>
+<p class="docs-section-number">02 / EXECUTION MODEL</p>
+
+## One controlled path from goal to chain.
+
+Every write operation should be explainable before it becomes irreversible. The framework makes the execution boundary explicit.
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🔮</span>
-### Oracle Aggregator
-Multi-source price feeds — Chainlink, DexScreener, CoinGecko. Weighted median, auto-fallback, cache.
+<div class="execution-path" markdown>
+<div><span>01</span><strong>Intent</strong><small>Natural language or Python call</small></div>
+<div><span>02</span><strong>Plan</strong><small>Tool routing and parameters</small></div>
+<div><span>03</span><strong>Policy</strong><small>Limits, approval, simulation</small></div>
+<div><span>04</span><strong>Execute</strong><small>Signed transaction on-chain</small></div>
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">📡</span>
-### Event Listener
-On-chain event subscription with webhooks, callbacks, and background polling. Real-time monitoring.
+<div class="docs-callout" markdown>
+<span>i</span>
+<p><strong>Designed for controlled automation.</strong> The framework is beta software. Review the [maturity policy](project-maturity.md) and [risk disclosure](../RISKS.md) before using real funds.</p>
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🧪</span>
-### Transaction Simulator
-Pre-flight TX verification via eth_call, Tenderly, or local fork. Catch reverts before broadcasting.
+<div class="docs-rule"></div>
+
+<div class="docs-section-intro docs-section-intro-small" markdown>
+<p class="docs-section-number">03 / START HERE</p>
+
+## Small surface. Serious foundations.
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🔑</span>
-### Account Abstraction
-ERC-4337 bundler, paymaster integration, smart account factory. SimpleAccount, Safe, Kernel support.
+<div class="docs-start-grid" markdown>
+<div markdown>
+<span class="start-label">FIRST RUN</span>
+### Build your first agent
+Install the package, configure a wallet, and run a read-only balance check.
+
+[Open Getting Started →](getting-started.md)
+</div>
+<div markdown>
+<span class="start-label">TERMINAL</span>
+### Use the `wak` CLI
+Inspect chains, check dependencies, run examples, and operate without writing Python.
+
+[Open CLI reference →](cli.md)
+</div>
+<div markdown>
+<span class="start-label">REFERENCE</span>
+### Browse the API
+Go deeper into wallets, chains, LLMs, DeFi, bridges, security, and execution modules.
+
+[Open API reference →](api/agent.md)
+</div>
 </div>
 
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🔗</span>
-### Cross-Chain Messaging
-LayerZero + Wormhole + CCIP unified API. Send messages, query status, estimate fees.
-</div>
-
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🗳️</span>
-### Governance
-Snapshot + Tally + on-chain governor. Proposal tracking, voting power, delegation management.
-</div>
-
-<div class="tx-feature" markdown>
-<span class="tx-feature-icon">🛠️</span>
-### CLI Tool
-`wak` — 7 commands for terminal usage. Check balances, gas, run agents, zero Python.
-</div>
-
-</div>
-
-<div class="tx-divider"></div>
-
-## 🏗️ Architecture
-
-```
-User / Application
-        │
-        ▼
-┌───────────────────────────┐
-│     Agent Framework       │
-│  Goal → LLM → Tool → TX  │
-└─────────────┬─────────────┘
-              │
-   ┌──────────┼──────────┐
-   │   Safety Layer      │
-   │  Governor + Kill SW │
-   └──────────┼──────────┘
-              │
-   ┌──────────┼────────────────────────────────────────┐
-   │          Tool Ecosystem                            │
-   │  DeFi · Airdrop · Security · MEV · NFT · Trading   │
-   │  Portfolio · Bridge · Gas · Wallet · Oracle        │
-   │  Events · Simulator · Account Abstraction          │
-   │  Messaging · Governance · Plugins · Utils          │
-   └──────────┼────────────────────────────────────────┘
-              │
-   ┌──────────┼──────────┐
-   │  Chain Abstraction   │
-   │  ETH · BASE · ARB   │
-   │  OP · MATIC · BSC   │
-   │  AVAX · SOLANA   │
-   └─────────────────────┘
-```
-
-<div class="tx-divider"></div>
-
-## ⚡ Quick Start
-
-=== "Python"
-
-    ```python
-    from web3_agent_kit import Agent, Wallet, Chain, ChainManager
-    from web3_agent_kit.defi import Uniswap
-
-    chain_manager = ChainManager(chains=[Chain.BASE])
-    wallet = Wallet.from_env("PRIVATE_KEY", chain_manager=chain_manager)
-    uniswap = Uniswap(chain_manager=chain_manager)
-
-    agent = Agent(wallet=wallet, chains=[Chain.BASE], tools=[uniswap])
-    result = agent.run("Swap 0.1 ETH to USDC on Base")
-    ```
-
-=== "CLI"
-
-    ```bash
-    # Check your wallet
-    wak wallet
-
-    # Check gas prices
-    wak gas
-
-    # Run an agent
-    wak agent --goal "Swap 0.1 ETH to USDC on Base" --wallet 0x...
-    ```
-
-=== "Airdrop Farming"
-
-    ```python
-    from web3_agent_kit.airdrop import MultiWalletManager
-
-    manager = MultiWalletManager.from_csv("wallets.csv")
-    manager.execute_on_all("swap", token_in="ETH", token_out="USDC", amount=0.01)
-    ```
-
-=== "Security Audit"
-
-    ```python
-    from web3_agent_kit.security import StaticAnalyzer
-
-    analyzer = StaticAnalyzer()
-    results = analyzer.analyze("contracts/Token.sol")
-    for vuln in results.vulnerabilities:
-        print(f"[{vuln.severity}] {vuln.name}")
-    ```
-
-=== "Oracle"
-
-    ```python
-    from web3_agent_kit.oracle import OracleAggregator
-
-    oracle = OracleAggregator()
-    price = oracle.get_price("ETH")
-    print(f"ETH: ${price.usd:.2f} (sources: {price.sources})")
-    ```
-
-=== "Simulate TX"
-
-    ```python
-    from web3_agent_kit.simulator import TransactionSimulator
-
-    sim = TransactionSimulator(chain_manager=cm)
-    result = sim.simulate(to=router, data=calldata, from_addr=wallet.address)
-    print(f"Would revert: {result.would_revert}, gas: {result.gas_used}")
-    ```
-
-<div class="tx-divider"></div>
-
-## 📦 Supported Chains
-
-| Chain | Status | DeFi | Bridge |
-|-------|:------:|:----:|:------:|
-| Ethereum | ✅ | ✅ | ✅ |
-| Base | ✅ | ✅ | ✅ |
-| Arbitrum | ✅ | ✅ | ✅ |
-| Optimism | ✅ | ✅ | ✅ |
-| Polygon | ✅ | ✅ | ✅ |
-| Avalanche | ✅ | — | ✅ |
-| BSC | ✅ | — | ✅ |
-| Solana | ✅ | — | — |
-
-<div class="tx-divider"></div>
-
-## 🤝 Contributing
-
-We welcome contributions! Whether it's bug reports, feature requests, documentation improvements, or code contributions.
-
-[Contributing Guide](contributing.md){ .md-button .md-button--primary }
-
-<div class="tx-divider"></div>
-
-<div style="text-align: center; opacity: 0.6; font-size: 0.85rem;">
-
-Built by [Maulana](https://github.com/ulsreall) · [Twitter](https://twitter.com/itseywacc) · [PyPI](https://pypi.org/project/web3-agent-kit/)
-
+<div class="docs-footer-cta" markdown>
+<div><span class="docs-section-number">OPEN SOURCE · MIT LICENSE</span><strong>Build on the source, not a black box.</strong></div>
+[GitHub repository →](https://github.com/ulsreall/web3-agent-kit){ .md-button .md-button--primary }
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,727 +1,108 @@
-/* ============================================
-   Web3 Agent Kit — Custom Docs Theme
-   Responsive-first, mobile-optimized
-   ============================================ */
-
-/* ---------- Custom Colors ---------- */
+/* Web3 Agent Kit docs — restrained product documentation theme */
 :root {
-  --md-primary-fg-color: #6366f1;
-  --md-primary-fg-color--light: #818cf8;
-  --md-primary-fg-color--dark: #4f46e5;
-  --md-accent-fg-color: #a855f7;
-  --md-accent-fg-color--transparent: rgba(168, 85, 247, 0.1);
-  --tx-radius: 16px;
-  --tx-radius-sm: 10px;
-  --tx-glow: rgba(99, 102, 241, 0.15);
+  --md-primary-fg-color: #0b0d0c;
+  --md-primary-fg-color--light: #171d19;
+  --md-primary-fg-color--dark: #050706;
+  --md-accent-fg-color: #16a66b;
+  --md-typeset-a-color: #138d5b;
+  --md-default-bg-color: #f7f9f7;
+  --md-default-fg-color: #172019;
+  --md-code-bg-color: #eef2ee;
+  --docs-accent: #16a66b;
+  --docs-accent-soft: rgba(22, 166, 107, .10);
+  --docs-ink: #172019;
+  --docs-muted: #657168;
+  --docs-line: rgba(23, 32, 25, .13);
+  --docs-surface: #ffffff;
+  --docs-surface-2: #f0f4f1;
+  --docs-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
 [data-md-color-scheme="slate"] {
-  --md-primary-fg-color: #818cf8;
-  --md-primary-fg-color--light: #a5b4fc;
-  --md-primary-fg-color--dark: #6366f1;
-  --md-accent-fg-color: #a855f7;
-  --md-default-bg-color: #0f0f1a;
-  --md-code-bg-color: #1e1e2e;
+  --md-primary-fg-color: #101512;
+  --md-primary-fg-color--light: #1b241e;
+  --md-primary-fg-color--dark: #080b09;
+  --md-accent-fg-color: #3ddc97;
+  --md-typeset-a-color: #54dca0;
+  --md-default-bg-color: #0b0d0c;
+  --md-default-fg-color: #e6ece7;
+  --md-default-fg-color--light: #a6b1a8;
+  --md-code-bg-color: #111612;
+  --docs-accent: #3ddc97;
+  --docs-accent-soft: rgba(61, 220, 151, .11);
+  --docs-ink: #e6ece7;
+  --docs-muted: #9da99f;
+  --docs-line: rgba(214, 230, 217, .14);
+  --docs-surface: #101512;
+  --docs-surface-2: #151c17;
 }
 
-/* ---------- Base ---------- */
-html {
-  scroll-behavior: smooth;
-  -webkit-text-size-adjust: 100%;
+html { scroll-behavior: smooth; }
+body { -webkit-font-smoothing: antialiased; }
+.md-header { background: rgba(11, 13, 12, .94); border-bottom: 1px solid rgba(214, 230, 217, .10); box-shadow: none; }
+[data-md-color-scheme="default"] .md-header { background: rgba(247, 249, 247, .94); border-bottom-color: var(--docs-line); }
+.md-header__button.md-logo img { width: 30px; height: 30px; border-radius: 8px; }
+.md-tabs { background: var(--md-primary-fg-color); border-bottom: 1px solid var(--docs-line); }
+.md-tabs__link { opacity: .72; font-size: .72rem; letter-spacing: .02em; }
+.md-tabs__link--active, .md-tabs__link:hover { opacity: 1; }
+.md-nav__title { font-weight: 600; letter-spacing: -.02em; }
+.md-sidebar__scrollwrap { scrollbar-width: thin; }
+.md-sidebar--secondary { border-left: 1px solid var(--docs-line); }
+.md-nav__link { font-size: .73rem; }
+.md-nav__link--active { color: var(--docs-accent); font-weight: 600; }
+.md-search__form { border-radius: 3px; background: rgba(255,255,255,.08); }
+[data-md-color-scheme="default"] .md-search__form { background: rgba(23,32,25,.06); }
+
+/* The landing page is intentionally more editorial than the default Material cards. */
+.md-content__inner:before { display: none; }
+.md-content__inner { max-width: 1180px; padding-top: 0; }
+.md-typeset h1 { font-weight: 650; letter-spacing: -.055em; }
+.md-typeset h2 { font-weight: 600; letter-spacing: -.045em; }
+.md-typeset h3 { font-weight: 600; letter-spacing: -.025em; }
+.md-typeset code { border-radius: 3px; font-size: .82em; }
+.md-typeset pre > code { border-radius: 0; }
+.md-typeset .admonition, .md-typeset details { border-radius: 3px; box-shadow: none; }
+.md-typeset a { text-underline-offset: 3px; }
+
+.docs-hero { display: grid; grid-template-columns: minmax(0, 1.02fr) minmax(360px, .98fr); gap: clamp(34px, 7vw, 95px); align-items: center; min-height: 570px; padding: 70px 0 62px; }
+.docs-hero-copy { min-width: 0; }
+.docs-eyebrow, .docs-section-number, .start-label, .docs-install > span, .terminal-foot, .terminal-bar { font-family: var(--docs-mono); font-size: .65rem; text-transform: uppercase; letter-spacing: .10em; }
+.docs-eyebrow { color: var(--docs-accent); margin: 0 0 22px; }
+.docs-eyebrow span { color: var(--docs-muted); margin: 0 6px; }
+.docs-hero h1 { max-width: 620px; margin: 0 0 22px; color: var(--docs-ink); font-size: clamp(2.75rem, 5.7vw, 5rem); line-height: .98; letter-spacing: -.075em; font-weight: 650; }
+.docs-hero-copy > p:not(.docs-eyebrow) { max-width: 585px; color: var(--docs-muted); font-size: 1.02rem; line-height: 1.75; }
+.docs-actions { display: flex; flex-wrap: wrap; gap: 10px; margin: 29px 0 25px; }
+.docs-actions .md-button, .docs-footer-cta .md-button { border-radius: 3px; font-size: .76rem; font-weight: 600; letter-spacing: .01em; }
+.docs-actions .md-button--primary, .docs-footer-cta .md-button--primary { border-color: var(--docs-accent); background: var(--docs-accent); color: #06130c; }
+.docs-actions .md-button:not(.md-button--primary), .docs-footer-cta .md-button:not(.md-button--primary) { border-color: var(--docs-line); color: var(--docs-ink); }
+.docs-install { display: inline-flex; align-items: center; gap: 14px; min-height: 40px; padding: 0 13px; border: 1px solid var(--docs-line); background: var(--docs-surface-2); color: var(--docs-ink); font: .73rem var(--docs-mono); }
+.docs-install > span { color: var(--docs-muted); font-size: .58rem; }
+.docs-install code { padding: 0; background: transparent; color: var(--docs-ink); }
+
+.docs-terminal { overflow: hidden; border: 1px solid var(--docs-line); background: #0e1310; box-shadow: 0 22px 60px rgba(0,0,0,.16); }
+.terminal-bar { display: flex; align-items: center; gap: 6px; height: 43px; padding: 0 15px; border-bottom: 1px solid rgba(214,230,217,.13); color: #84958a; font-size: .57rem; }
+.terminal-bar span { width: 7px; height: 7px; border-radius: 50%; background: #597364; }.terminal-bar span:first-child { background: #a87570; }.terminal-bar span:nth-child(2) { background: #b29a67; }.terminal-bar b { margin-left: 8px; font-weight: 400; letter-spacing: .04em; }.terminal-bar i { margin-left: auto; color: #3ddc97; font-style: normal; font-size: .56rem; }
+.docs-terminal pre { margin: 0; padding: 24px 20px 21px; background: #0e1310; color: #d6e2d8; font-size: .72rem; line-height: 1.85; }
+.docs-terminal .highlight { background: transparent; }
+.docs-terminal .terminal-foot { padding: 12px 17px; border-top: 1px solid rgba(214,230,217,.13); color: #789082; font-size: .56rem; }
+
+.docs-metrics { display: grid; grid-template-columns: repeat(5, 1fr); border-top: 1px solid var(--docs-line); border-bottom: 1px solid var(--docs-line); }
+.docs-metrics > div { min-height: 92px; display: flex; flex-direction: column; justify-content: center; padding: 0 19px; border-right: 1px solid var(--docs-line); }.docs-metrics > div:first-child { padding-left: 0; }.docs-metrics > div:last-child { border-right: 0; }
+.docs-metrics strong { color: var(--docs-ink); font-size: 1.55rem; font-weight: 550; letter-spacing: -.06em; }.docs-metrics span { margin-top: 2px; color: var(--docs-muted); font: .58rem var(--docs-mono); text-transform: uppercase; letter-spacing: .08em; }
+.docs-rule { height: 1px; margin: 0; background: var(--docs-line); }
+.docs-section-intro { display: grid; grid-template-columns: 120px minmax(0, 680px); column-gap: 30px; align-items: start; padding: 94px 0 40px; }.docs-section-number { margin: 9px 0 0; color: var(--docs-accent); font-size: .58rem; }.docs-section-intro h2 { grid-column: 2; margin: 0 0 13px; color: var(--docs-ink); font-size: clamp(2rem, 4vw, 3.3rem); line-height: 1.02; }.docs-section-intro h2 + p { grid-column: 2; max-width: 570px; margin: 0; color: var(--docs-muted); line-height: 1.7; }.docs-section-intro-small { padding-bottom: 32px; }
+.docs-capabilities { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }.docs-capability { min-height: 235px; display: flex; flex-direction: column; padding: 23px; border: 1px solid var(--docs-line); background: var(--docs-surface); }.docs-capability-dark { color: #e1ebe3; background: #141b16; }.capability-number { color: var(--docs-accent); font: .64rem var(--docs-mono); }.docs-capability h3 { margin: 31px 0 8px; color: var(--docs-ink); font-size: 1.08rem; }.docs-capability-dark h3 { color: #e1ebe3; }.docs-capability p { margin: 0; color: var(--docs-muted); font-size: .78rem; line-height: 1.65; }.docs-capability-dark p { color: #a9b8ad; }.docs-capability a { margin-top: auto; padding-top: 19px; color: var(--docs-ink); font: .64rem var(--docs-mono); }.docs-capability-dark a { color: #e1ebe3; }.docs-capability-wide { grid-column: span 2; min-height: 180px; }.chain-list { display: flex; flex-wrap: wrap; gap: 7px; margin-top: auto; padding-top: 22px; }.chain-list span { padding: 5px 7px; border: 1px solid var(--docs-line); color: var(--docs-muted); font: .6rem var(--docs-mono); }
+.execution-path { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--docs-line); background: var(--docs-surface); }.execution-path > div { min-height: 137px; display: flex; flex-direction: column; padding: 21px; }.execution-path > div + div { border-left: 1px solid var(--docs-line); }.execution-path > div:last-child { background: var(--docs-accent-soft); }.execution-path span { color: var(--docs-accent); font: .6rem var(--docs-mono); }.execution-path strong { margin-top: 28px; color: var(--docs-ink); font-size: .95rem; font-weight: 600; }.execution-path small { margin-top: 3px; color: var(--docs-muted); font-size: .68rem; line-height: 1.4; }.docs-callout { display: grid; grid-template-columns: 25px 1fr; gap: 13px; align-items: start; margin-top: 11px; padding: 16px 18px; border: 1px solid var(--docs-line); color: var(--docs-muted); }.docs-callout > span { display: grid; place-items: center; width: 20px; height: 20px; border: 1px solid var(--docs-accent); color: var(--docs-accent); font: .7rem var(--docs-mono); }.docs-callout p { margin: 0; font-size: .75rem; line-height: 1.6; }.docs-callout strong { color: var(--docs-ink); }
+.docs-start-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }.docs-start-grid > div { min-height: 190px; display: flex; flex-direction: column; padding: 22px; border-top: 2px solid var(--docs-line); background: var(--docs-surface); }.docs-start-grid > div:hover { border-top-color: var(--docs-accent); }.start-label { color: var(--docs-muted); font-size: .57rem; }.docs-start-grid h3 { margin: 25px 0 9px; color: var(--docs-ink); font-size: 1rem; }.docs-start-grid p { margin: 0; color: var(--docs-muted); font-size: .76rem; line-height: 1.6; }.docs-start-grid a { margin-top: auto; padding-top: 18px; color: var(--docs-ink); font: .63rem var(--docs-mono); }
+.docs-footer-cta { display: flex; align-items: center; justify-content: space-between; gap: 22px; margin: 100px 0 65px; padding: 24px; border: 1px solid var(--docs-line); background: var(--docs-surface-2); }.docs-footer-cta > div { display: flex; flex-direction: column; gap: 7px; }.docs-footer-cta .docs-section-number { margin: 0; }.docs-footer-cta strong { color: var(--docs-ink); font-size: 1.05rem; font-weight: 600; }
+
+/* Content pages: quiet, readable, and consistent with the landing page. */
+.md-typeset table:not([class]) { border: 1px solid var(--docs-line); border-radius: 2px; box-shadow: none; }.md-typeset table:not([class]) th { background: var(--docs-surface-2); color: var(--docs-ink); font-size: .72rem; }.md-typeset table:not([class]) td { font-size: .76rem; }.md-typeset .tabbed-labels > label { font-size: .72rem; }.md-typeset .highlight { border: 1px solid var(--docs-line); }.md-typeset .highlight pre { background: var(--docs-surface-2); }.md-typeset blockquote { border-left-color: var(--docs-accent); }
+
+@media (max-width: 900px) {
+  .docs-hero { grid-template-columns: 1fr; min-height: auto; padding: 55px 0 52px; gap: 42px; }.docs-terminal { max-width: 680px; }.docs-metrics { grid-template-columns: repeat(5, 1fr); }.docs-metrics > div { padding: 0 11px; }.docs-capabilities { grid-template-columns: 1fr 1fr; }.docs-capability-wide { grid-column: span 2; }.docs-section-intro { grid-template-columns: 90px minmax(0, 1fr); }
 }
-
-/* ---------- Header ---------- */
-.md-header {
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  background: rgba(15, 15, 26, 0.85);
+@media (max-width: 600px) {
+  .md-content__inner { padding: 0 16px; }.docs-hero { padding-top: 40px; }.docs-hero h1 { font-size: clamp(2.5rem, 14vw, 4rem); }.docs-hero-copy > p:not(.docs-eyebrow) { font-size: .9rem; }.docs-actions { flex-direction: column; align-items: stretch; }.docs-actions .md-button { text-align: center; }.docs-install { width: 100%; justify-content: space-between; font-size: .65rem; }.docs-terminal pre { padding: 17px 13px; overflow-x: auto; font-size: .62rem; }.docs-metrics { grid-template-columns: repeat(2, 1fr); }.docs-metrics > div { min-height: 75px; padding: 0 12px; }.docs-metrics > div:nth-child(2) { border-right: 0; }.docs-metrics > div:nth-child(n+3) { border-top: 1px solid var(--docs-line); }.docs-metrics > div:first-child { padding-left: 12px; }.docs-metrics > div:last-child { border-right: 0; }.docs-section-intro { display: block; padding: 70px 0 28px; }.docs-section-intro .docs-section-number { margin-bottom: 24px; }.docs-section-intro h2 { font-size: 2.15rem; }.docs-capabilities, .docs-start-grid { grid-template-columns: 1fr; }.docs-capability-wide { grid-column: auto; }.docs-capability { min-height: 200px; }.execution-path { grid-template-columns: 1fr 1fr; }.execution-path > div { min-height: 112px; padding: 16px; }.execution-path > div:nth-child(3) { border-left: 0; border-top: 1px solid var(--docs-line); }.execution-path > div:nth-child(4) { border-top: 1px solid var(--docs-line); }.execution-path strong { margin-top: 18px; }.docs-footer-cta { align-items: flex-start; flex-direction: column; margin-top: 72px; }.docs-footer-cta .md-button { width: 100%; text-align: center; }.md-typeset .highlight pre { font-size: .7rem; }
 }
-
-[data-md-color-scheme="default"] .md-header {
-  background: rgba(255, 255, 255, 0.85);
-}
-
-/* ---------- Hero Section ---------- */
-.tx-hero {
-  padding: 4rem 1.5rem 3rem;
-  text-align: center;
-  max-width: 900px;
-  margin: 0 auto;
-}
-
-.tx-hero h1 {
-  font-size: clamp(2rem, 5vw, 3.5rem);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  line-height: 1.1;
-  background: linear-gradient(135deg, #a855f7 0%, #6366f1 40%, #06b6d4 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin-bottom: 0.75rem;
-  word-break: break-word;
-}
-
-.tx-hero .tx-hero-sub {
-  font-size: clamp(1rem, 2.5vw, 1.3rem);
-  opacity: 0.8;
-  max-width: 600px;
-  margin: 0 auto 1.5rem;
-  line-height: 1.6;
-  padding: 0 0.5rem;
-}
-
-.tx-hero .tx-hero-code {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: clamp(0.8rem, 1.5vw, 0.95rem);
-  background: rgba(99, 102, 241, 0.08);
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  border-radius: var(--tx-radius);
-  padding: 0.85rem 1.25rem;
-  display: inline-block;
-  margin: 0.75rem auto;
-  max-width: 100%;
-  text-align: left;
-  overflow-x: auto;
-}
-
-[data-md-color-scheme="slate"] .tx-hero .tx-hero-code {
-  background: rgba(99, 102, 241, 0.12);
-  border-color: rgba(99, 102, 241, 0.25);
-}
-
-.tx-hero-buttons {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 1.5rem;
-  padding: 0 0.5rem;
-}
-
-.tx-hero-buttons a {
-  border-radius: var(--tx-radius-sm);
-  padding: 0.7rem 1.75rem;
-  font-weight: 600;
-  font-size: clamp(0.85rem, 1.5vw, 1rem);
-  text-decoration: none;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  border: none;
-  white-space: nowrap;
-}
-
-.tx-hero-buttons .md-button--primary {
-  background: linear-gradient(135deg, #a855f7, #6366f1);
-  color: #fff;
-  box-shadow: 0 4px 20px rgba(99, 102, 241, 0.3);
-}
-
-.tx-hero-buttons .md-button--primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 30px rgba(99, 102, 241, 0.45);
-  color: #fff;
-}
-
-.tx-hero-buttons .md-button {
-  background: transparent;
-  border: 2px solid rgba(99, 102, 241, 0.3);
-  color: #6366f1;
-}
-
-.tx-hero-buttons .md-button:hover {
-  background: rgba(99, 102, 241, 0.08);
-  border-color: #6366f1;
-  transform: translateY(-2px);
-}
-
-/* ---------- Animated gradient bg ---------- */
-.tx-hero-gradient {
-  position: relative;
-  overflow: hidden;
-}
-
-.tx-hero-gradient::before {
-  content: '';
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(ellipse at 30% 50%, rgba(168, 85, 247, 0.06) 0%, transparent 60%),
-              radial-gradient(ellipse at 70% 50%, rgba(6, 182, 212, 0.04) 0%, transparent 60%);
-  animation: tx-float 20s ease-in-out infinite alternate;
-  z-index: -1;
-}
-
-@keyframes tx-float {
-  0% { transform: translate(0, 0) rotate(0deg); }
-  100% { transform: translate(3%, -3%) rotate(3deg); }
-}
-
-/* ---------- Stats Bar ---------- */
-.tx-stats {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1rem;
-  padding: 1.5rem 1rem;
-  margin: 1rem auto 2rem;
-  max-width: 800px;
-  border-top: 1px solid rgba(99, 102, 241, 0.15);
-  border-bottom: 1px solid rgba(99, 102, 241, 0.15);
-}
-
-.tx-stats .stat {
-  text-align: center;
-  padding: 0.25rem;
-}
-
-.tx-stats .stat-num {
-  font-size: clamp(1.3rem, 3vw, 1.8rem);
-  font-weight: 800;
-  background: linear-gradient(135deg, #a855f7, #06b6d4);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  line-height: 1.2;
-}
-
-.tx-stats .stat-label {
-  font-size: clamp(0.6rem, 1.2vw, 0.8rem);
-  opacity: 0.6;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-top: 0.15rem;
-}
-
-/* ---------- Feature Grid ---------- */
-.tx-features {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-  margin: 2rem 0;
-}
-
-.tx-feature {
-  padding: 1.5rem;
-  border-radius: var(--tx-radius);
-  border: 1px solid rgba(99, 102, 241, 0.1);
-  background: rgba(99, 102, 241, 0.02);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  display: flex;
-  flex-direction: column;
-}
-
-.tx-feature:hover {
-  border-color: rgba(99, 102, 241, 0.3);
-  background: rgba(99, 102, 241, 0.06);
-  transform: translateY(-6px);
-  box-shadow: 0 12px 40px rgba(99, 102, 241, 0.12);
-}
-
-[data-md-color-scheme="slate"] .tx-feature {
-  border-color: rgba(99, 102, 241, 0.15);
-  background: rgba(99, 102, 241, 0.04);
-}
-
-[data-md-color-scheme="slate"] .tx-feature:hover {
-  border-color: rgba(168, 85, 247, 0.35);
-  background: rgba(99, 102, 241, 0.08);
-  box-shadow: 0 12px 40px rgba(168, 85, 247, 0.1);
-}
-
-.tx-feature-icon {
-  font-size: 2rem;
-  margin-bottom: 0.75rem;
-  display: block;
-  line-height: 1;
-}
-
-.tx-feature h3 {
-  font-size: 1.05rem;
-  font-weight: 700;
-  margin: 0 0 0.5rem;
-  line-height: 1.3;
-}
-
-.tx-feature p {
-  font-size: 0.88rem;
-  opacity: 0.7;
-  margin: 0;
-  line-height: 1.55;
-  flex-grow: 1;
-}
-
-/* ---------- Code Blocks ---------- */
-.md-typeset pre {
-  border-radius: var(--tx-radius);
-  border: 1px solid rgba(99, 102, 241, 0.1);
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-[data-md-color-scheme="slate"] .md-typeset pre {
-  background: #1e1e2e;
-  border-color: rgba(99, 102, 241, 0.15);
-}
-
-.md-typeset code {
-  font-size: 0.85em;
-  word-break: break-word;
-}
-
-/* ---------- Admonition Cards ---------- */
-.md-typeset .admonition,
-.md-typeset details {
-  border-radius: var(--tx-radius);
-  border: 1px solid rgba(99, 102, 241, 0.12);
-}
-
-.md-typeset .admonition.tip { border-color: rgba(16, 185, 129, 0.3); }
-.md-typeset .admonition.note { border-color: rgba(99, 102, 241, 0.3); }
-.md-typeset .admonition.warning { border-color: rgba(245, 158, 11, 0.3); }
-
-/* ---------- Section Headers ---------- */
-.md-typeset h2 {
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  padding-bottom: 0.4rem;
-  border-bottom: 2px solid rgba(99, 102, 241, 0.12);
-  margin-top: 2.5rem;
-}
-
-.md-typeset h3 {
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-/* ---------- Navigation ---------- */
-.md-nav__item--active > .md-nav__link {
-  font-weight: 600;
-  color: #a855f7;
-}
-
-.md-sidebar--secondary .md-nav__link {
-  font-size: 0.8rem;
-}
-
-.md-sidebar--secondary .md-nav__link--active {
-  color: #a855f7;
-  font-weight: 600;
-}
-
-/* ---------- Footer ---------- */
-.md-footer {
-  margin-top: 3rem;
-}
-
-.md-footer-meta {
-  backdrop-filter: blur(16px);
-}
-
-/* ---------- Copy button ---------- */
-.md-typeset .highlight button {
-  border-radius: 6px;
-  opacity: 0;
-  transition: opacity 0.2s;
-}
-
-.md-typeset .highlight:hover button {
-  opacity: 1;
-}
-
-/* ---------- Table ---------- */
-.md-typeset table:not([class]) {
-  border-radius: var(--tx-radius);
-  overflow: hidden;
-  display: block;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-.md-typeset table:not([class]) th {
-  background: rgba(99, 102, 241, 0.06);
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.md-typeset table:not([class]) td {
-  white-space: nowrap;
-}
-
-/* ---------- Tabs ---------- */
-.md-typeset .tabbed-set > label {
-  border-radius: var(--tx-radius-sm) var(--tx-radius-sm) 0 0;
-  padding: 0.6rem 1.2rem;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.md-typeset .tabbed-content {
-  border-radius: 0 var(--tx-radius) var(--tx-radius) var(--tx-radius);
-}
-
-/* ---------- Divider ---------- */
-.tx-divider {
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(99, 102, 241, 0.2), transparent);
-  margin: 3rem 0;
-}
-
-/* ---------- Install badge ---------- */
-.tx-install {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  background: rgba(99, 102, 241, 0.08);
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  border-radius: var(--tx-radius-sm);
-  padding: 0.6rem 1.2rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.9rem;
-  margin: 0.5rem 0;
-}
-
-.tx-install code {
-  background: none;
-  padding: 0;
-  font-size: 0.9rem;
-}
-
-/* ============================================
-   RESPONSIVE BREAKPOINTS
-   ============================================ */
-
-/* ---------- Tablet Landscape (< 1200px) ---------- */
-@media screen and (max-width: 75em) {
-  .tx-features {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1rem;
-  }
-  
-  .tx-feature {
-    padding: 1.25rem;
-  }
-}
-
-/* ---------- Tablet Portrait (< 960px) ---------- */
-@media screen and (max-width: 60em) {
-  .tx-hero {
-    padding: 3rem 1.25rem 2rem;
-  }
-  
-  .tx-features {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-  }
-  
-  .tx-stats {
-    grid-template-columns: repeat(5, 1fr);
-    gap: 0.5rem;
-    padding: 1.25rem 0.75rem;
-  }
-  
-  .md-typeset table:not([class]) {
-    font-size: 0.85rem;
-  }
-}
-
-/* ---------- Mobile Landscape (< 768px) ---------- */
-@media screen and (max-width: 48em) {
-  .tx-hero {
-    padding: 2.5rem 1rem 1.5rem;
-  }
-  
-  .tx-hero h1 {
-    font-size: 2rem;
-  }
-  
-  .tx-hero .tx-hero-sub {
-    font-size: 1rem;
-    margin-bottom: 1rem;
-  }
-  
-  .tx-hero-buttons {
-    flex-direction: column;
-    align-items: center;
-    gap: 0.6rem;
-  }
-  
-  .tx-hero-buttons a {
-    width: 100%;
-    max-width: 280px;
-    text-align: center;
-    padding: 0.75rem 1.5rem;
-  }
-  
-  .tx-stats {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 0.75rem;
-    padding: 1rem 0.5rem;
-  }
-  
-  .tx-stats .stat:nth-child(4),
-  .tx-stats .stat:nth-child(5) {
-    grid-column: span 1;
-  }
-  
-  .tx-features {
-    grid-template-columns: 1fr;
-    gap: 0.75rem;
-  }
-  
-  .tx-feature {
-    padding: 1.25rem;
-    flex-direction: row;
-    align-items: flex-start;
-    gap: 1rem;
-  }
-  
-  .tx-feature-icon {
-    font-size: 1.5rem;
-    margin-bottom: 0;
-    min-width: 2rem;
-    text-align: center;
-  }
-  
-  .tx-feature h3 {
-    font-size: 1rem;
-  }
-  
-  .tx-feature p {
-    font-size: 0.85rem;
-  }
-  
-  .tx-divider {
-    margin: 2rem 0;
-  }
-  
-  /* Tabs scrollable on mobile */
-  .md-typeset .tabbed-set {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-  
-  .md-typeset .tabbed-set > label {
-    padding: 0.5rem 0.8rem;
-    font-size: 0.8rem;
-    white-space: nowrap;
-  }
-  
-  /* Table horizontal scroll */
-  .md-typeset table:not([class]) {
-    display: block;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-  
-  /* Code blocks */
-  .md-typeset pre {
-    font-size: 0.8rem;
-    padding: 0.75rem;
-  }
-  
-  .md-typeset .highlight button {
-    opacity: 0.8;
-  }
-  
-  /* Sidebar */
-  .md-sidebar--primary {
-    width: 14rem;
-  }
-}
-
-/* ---------- Mobile Portrait (< 576px) ---------- */
-@media screen and (max-width: 36em) {
-  .tx-hero {
-    padding: 2rem 0.75rem 1.25rem;
-  }
-  
-  .tx-hero h1 {
-    font-size: 1.75rem;
-  }
-  
-  .tx-hero .tx-hero-sub {
-    font-size: 0.9rem;
-    padding: 0;
-  }
-  
-  .tx-hero .tx-hero-code {
-    font-size: 0.78rem;
-    padding: 0.7rem 1rem;
-    border-radius: 12px;
-  }
-  
-  .tx-hero-buttons a {
-    max-width: 100%;
-    padding: 0.7rem 1.25rem;
-    font-size: 0.9rem;
-  }
-  
-  .tx-stats {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.5rem;
-  }
-  
-  .tx-stats .stat:last-child {
-    grid-column: span 2;
-  }
-  
-  .tx-stats .stat-num {
-    font-size: 1.3rem;
-  }
-  
-  .tx-stats .stat-label {
-    font-size: 0.65rem;
-  }
-  
-  .tx-features {
-    gap: 0.6rem;
-  }
-  
-  .tx-feature {
-    padding: 1rem;
-    border-radius: 12px;
-  }
-  
-  .tx-feature-icon {
-    font-size: 1.3rem;
-  }
-  
-  .tx-feature h3 {
-    font-size: 0.95rem;
-  }
-  
-  .tx-feature p {
-    font-size: 0.82rem;
-  }
-  
-  .md-typeset h2 {
-    font-size: 1.3rem;
-  }
-  
-  .md-typeset h3 {
-    font-size: 1.1rem;
-  }
-  
-  .md-typeset pre {
-    font-size: 0.75rem;
-    border-radius: 10px;
-  }
-  
-  .md-typeset .tabbed-set > label {
-    padding: 0.4rem 0.6rem;
-    font-size: 0.75rem;
-  }
-}
-
-/* ---------- Very Small Screens (< 375px) ---------- */
-@media screen and (max-width: 23.4375em) {
-  .tx-hero h1 {
-    font-size: 1.5rem;
-  }
-  
-  .tx-hero .tx-hero-sub {
-    font-size: 0.85rem;
-  }
-  
-  .tx-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  
-  .tx-stats .stat-num {
-    font-size: 1.1rem;
-  }
-  
-  .tx-hero-buttons a {
-    padding: 0.6rem 1rem;
-    font-size: 0.85rem;
-  }
-}
-
-/* ---------- Desktop Wide (> 1400px) ---------- */
-@media screen and (min-width: 87.5em) {
-  .tx-features {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1.5rem;
-  }
-  
-  .tx-feature {
-    padding: 2rem;
-  }
-  
-  .tx-feature-icon {
-    font-size: 2.25rem;
-  }
-  
-  .tx-feature h3 {
-    font-size: 1.15rem;
-  }
-}
-
-/* ---------- Touch Device Tweaks ---------- */
-@media (hover: none) {
-  .tx-feature:hover {
-    transform: none;
-    box-shadow: none;
-  }
-  
-  .tx-hero-buttons a:hover {
-    transform: none;
-  }
-  
-  .md-typeset .highlight button {
-    opacity: 0.8;
-  }
-}
-
-/* ---------- Print ---------- */
-@media print {
-  .tx-hero-gradient::before,
-  .md-header,
-  .md-footer,
-  .md-sidebar {
-    display: none;
-  }
-  
-  .tx-hero h1 {
-    -webkit-text-fill-color: #6366f1;
-    color: #6366f1;
-  }
-  
-  .tx-stats .stat-num {
-    -webkit-text-fill-color: #6366f1;
-    color: #6366f1;
-  }
-}
-
-/* ---------- Reduced Motion ---------- */
-@media (prefers-reduced-motion: reduce) {
-  .tx-hero-gradient::before {
-    animation: none;
-  }
-  
-  .tx-feature {
-    transition: none;
-  }
-  
-  .tx-hero-buttons a {
-    transition: none;
-  }
-  
-  html {
-    scroll-behavior: auto;
-  }
-}
-
-/* ---------- Focus Visible (Accessibility) ---------- */
-.tx-hero-buttons a:focus-visible,
-.tx-feature:focus-visible {
-  outline: 2px solid #a855f7;
-  outline-offset: 2px;
-}
-
-/* ---------- Selection Color ---------- */
-::selection {
-  background: rgba(168, 85, 247, 0.2);
-  color: inherit;
-}
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,8 +46,8 @@ theme:
     - announce.dismiss
   icon:
     repo: fontawesome/brands/github
-    logo: fontawesome/solid/robot
-  favicon: assets/favicon.png
+  logo: assets/logo-mark.svg
+  favicon: assets/favicon.svg
 
 plugins:
   - search


### PR DESCRIPTION
Replace the generic Material landing page treatment with an engineering-led docs experience: asymmetric hero, real execution preview, verified project metrics, restrained emerald/graphite theme, execution path, focused start-here cards, custom project mark, and responsive layout. Content pages retain the Material navigation and search system.